### PR TITLE
Issue #1: add check for openliberty.properties file

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntime.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntime.java
@@ -97,7 +97,8 @@ public class WebSphereRuntime extends RuntimeDelegate implements IJavaRuntime, I
     private static final String ENCODE = "encode";
     private static final String SU_OPTION_LISTCUSTOM = "--listCustom";
 
-    private static final String RUNTIME_MARKER = "lib/versions/WebSphereApplicationServer.properties";
+    public static final String RUNTIME_MARKER = "lib/versions/WebSphereApplicationServer.properties";
+    public static final String OPEN_RUNTIME_MARKER = "lib/versions/openliberty.properties";
 
     protected static final String PROP_VM_INSTALL_TYPE_ID = "vm-install-type-id";
     protected static final String PROP_VM_INSTALL_ID = "vm-install-id";
@@ -223,7 +224,7 @@ public class WebSphereRuntime extends RuntimeDelegate implements IJavaRuntime, I
     }
 
     public static boolean isValidLocation(IPath path) {
-        return path.append(RUNTIME_MARKER).toFile().exists();
+        return getRuntimePropertiesPath(path) != null;
     }
 
     public static List<IPath> findValidLocations(IPath path) {
@@ -2025,10 +2026,10 @@ public class WebSphereRuntime extends RuntimeDelegate implements IJavaRuntime, I
             return runtimeVersion;
         }
 
-        IPath path = getRuntimePath("lib");
-        if (path == null)
+        IPath path = getRuntimePropertiesPath();
+        if (path == null) {
             return null;
-        path = path.append("versions").append("WebSphereApplicationServer.properties");
+        }
         Properties prop = new Properties();
         FileUtil.loadProperties(prop, path);
         String s = prop.getProperty("com.ibm.websphere.productVersion");
@@ -2047,10 +2048,10 @@ public class WebSphereRuntime extends RuntimeDelegate implements IJavaRuntime, I
             return runtimeEdition;
         }
 
-        IPath path = getRuntimePath("lib");
-        if (path == null)
+        IPath path = getRuntimePropertiesPath();
+        if (path == null) {
             return null;
-        path = path.append("versions").append("WebSphereApplicationServer.properties");
+        }
         Properties prop = new Properties();
         FileUtil.loadProperties(prop, path);
         String s = prop.getProperty("com.ibm.websphere.productEdition");
@@ -2538,5 +2539,23 @@ public class WebSphereRuntime extends RuntimeDelegate implements IJavaRuntime, I
             return ".bat";
         }
         return "";
+    }
+
+    public IPath getRuntimePropertiesPath() {
+        return getRuntimePropertiesPath(getRuntime().getLocation());
+    }
+
+    public static IPath getRuntimePropertiesPath(IPath runtimeLocation) {
+        if (runtimeLocation == null || runtimeLocation.isEmpty())
+            return null;
+        IPath markerPath = runtimeLocation.append(RUNTIME_MARKER);
+        if (markerPath.toFile().exists()) {
+            return markerPath;
+        }
+        markerPath = runtimeLocation.append(OPEN_RUNTIME_MARKER);
+        if (markerPath.toFile().exists()) {
+            return markerPath;
+        }
+        return null;
     }
 }

--- a/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/RuntimeDropAdapter.java
+++ b/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/RuntimeDropAdapter.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.eclipse.core.runtime.CoreException;
@@ -84,7 +85,8 @@ import com.ibm.ws.st.ui.internal.wizard.WebSphereRuntimeWizardFragment;
  */
 @SuppressWarnings("restriction")
 public class RuntimeDropAdapter extends CommonDropAdapterAssistant {
-    private static final String RUNTIME_MARKER = "wlp/lib/versions/WebSphereApplicationServer.properties";
+    private static final String RUNTIME_MARKER = "wlp/" + WebSphereRuntime.RUNTIME_MARKER;
+    private static final String OPEN_RUNTIME_MARKER = "wlp/" + WebSphereRuntime.OPEN_RUNTIME_MARKER;
 
     private String filename;
     private IRuntime runtime;
@@ -276,7 +278,7 @@ public class RuntimeDropAdapter extends CommonDropAdapterAssistant {
         ZipFile zipFile = null;
         try {
             zipFile = new ZipFile(archiveFile);
-            return zipFile.getEntry(RUNTIME_MARKER) != null;
+            return (getRuntimeMarker(zipFile) != null);
         } catch (IOException e) {
             if (Trace.ENABLED)
                 Trace.trace(Trace.WARNING, "Problem reading archive: " + archiveFile, e);
@@ -289,6 +291,15 @@ public class RuntimeDropAdapter extends CommonDropAdapterAssistant {
                 // ignore
             }
         }
+    }
+
+    private static ZipEntry getRuntimeMarker(ZipFile zipFile) {
+        ZipEntry entry = zipFile.getEntry(RUNTIME_MARKER);
+        if (entry != null) {
+            return entry;
+        }
+        entry = zipFile.getEntry(OPEN_RUNTIME_MARKER);
+        return entry;
     }
 
     protected static boolean isAddonArchive(String filePath) {

--- a/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/download/DownloadHelper.java
+++ b/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/download/DownloadHelper.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.ui.internal.download;
 
@@ -75,9 +75,8 @@ public class DownloadHelper {
     private static FeatureInstaller featureInstaller = new FeatureInstaller();
     private static ConfigSnippetInstaller configSnippetInstaller = new ConfigSnippetInstaller();
 
-    private static final String[] SHARED_FOLDERS = new String[]
-    {
-     "usr/shared/apps", "usr/shared/config", "usr/shared/resources"
+    private static final String[] SHARED_FOLDERS = new String[] {
+                                                                  "usr/shared/apps", "usr/shared/config", "usr/shared/resources"
     };
 
     private static final NumberFormat numberFormat = NumberFormat.getIntegerInstance();
@@ -100,7 +99,7 @@ public class DownloadHelper {
 
     /**
      * Returns the given size in a formatted string.
-     * 
+     *
      * @param size the size in bytes
      */
     public static String getSize(long size) {
@@ -109,7 +108,7 @@ public class DownloadHelper {
 
     /**
      * Returns the given size in a formatted string.
-     * 
+     *
      * @param size the size in bytes
      */
     public static String getSize(long size, NumberFormat f) {
@@ -162,8 +161,8 @@ public class DownloadHelper {
                     if (monitor.isCanceled())
                         return;
                     Trace.logError("Error unzipping file: " + file.getName(), e);
-                    throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0,
-                                    NLS.bind(Messages.errorInstallingRuntimeEnvironment, path.toOSString() + "\n\n") + e.getLocalizedMessage(), e));
+                    throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0, NLS.bind(Messages.errorInstallingRuntimeEnvironment, path.toOSString() + "\n\n")
+                                                                                              + e.getLocalizedMessage(), e));
                 }
             }
         } finally {
@@ -305,7 +304,7 @@ public class DownloadHelper {
 
     /**
      * Unzip the input stream into the given path.
-     * 
+     *
      * @param srcFile
      * @param path
      * @param totalSize
@@ -592,7 +591,7 @@ public class DownloadHelper {
 
     /**
      * Check is SSL is working by trying to create a simple socket.
-     * 
+     *
      * @return <code>true</code> if SSL is working, and <code>false</code>
      *         if it fails due to missing classes.
      */
@@ -611,7 +610,7 @@ public class DownloadHelper {
     /**
      * Validates that the given folder exists as a folder on disk and is empty. Returns null if the folder is valid, and
      * returns an error message or "" (folder in empty) if the folder is invalid.
-     * 
+     *
      * @param folder
      * @return <code>null</code> if the folder is valid, and a non-null error otherwise
      */
@@ -656,10 +655,11 @@ public class DownloadHelper {
     public static IRuntimeInfo getRuntimeCore(final IRuntime runtime) {
         final WebSphereRuntime wsRuntime = (WebSphereRuntime) runtime.loadAdapter(WebSphereRuntime.class, null);
         final Properties prop = new Properties();
-        IPath path = runtime.getLocation();
-        if (path != null) {
-            path = path.append("lib").append("versions").append("WebSphereApplicationServer.properties");
-            FileUtil.loadProperties(prop, path);
+        if (wsRuntime != null) {
+            IPath path = wsRuntime.getRuntimePropertiesPath();
+            if (path != null) {
+                FileUtil.loadProperties(prop, path);
+            }
         }
 
         return new IRuntimeInfo() {
@@ -703,6 +703,9 @@ public class DownloadHelper {
 
             @Override
             public boolean isOnPremiseSupported() {
+                if (wsRuntime == null) {
+                    return false;
+                }
                 return wsRuntime.isOnPremiseSupported();
             }
         };


### PR DESCRIPTION
Fixes #1 

Check for both WebSphereApplicationServer.properties and openliberty.properties file in wlp/lib/versions so that all liberty runtimes can be supported.