### PR TITLE
Issue #12: Remote start not supported so remove related message

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Messages.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Messages.java
@@ -140,7 +140,6 @@ public class Messages extends NLS {
     public static String jmxConnectionFailure;
     public static String remoteJMXConnectionFailure;
     public static String errorPublishJMX;
-    public static String errorPublishRemoteServerNotStarted;
     public static String deployAppSuccessfully;
     public static String deployAppFailed;
     public static String errorDeleteFile;

--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Messages.properties
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Messages.properties
@@ -147,7 +147,6 @@ errorPublishModule=Publish {0} failed.
 jmxConnectionFailure=The JMX connection could not be established. Ensure that the appropriate features are enabled.
 remoteJMXConnectionFailure=The connection failed. If the server is started and the security credentials are correct, check the server logs for other problems.
 errorPublishJMX=Publish failed because JMX connection to the server could not be established.
-errorPublishRemoteServerNotStarted=The server needs to be started so that you can publish.  Start the server and publish again.
 deployAppSuccessfully=Application {0} is deployed successfully.
 deployAppFailed=Deployment of application {0} failed.
 errorDeleteFile=Could not delete file: {0}

--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereServerBehaviour.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereServerBehaviour.java
@@ -976,9 +976,7 @@ public class WebSphereServerBehaviour extends ServerBehaviourDelegate implements
 
             // can't publish to remote server if server isn't started or JMX connection unavailable
             if (jmxConnection == null && !isLocalUserDir()) {
-                if (getServer().getServerState() != IServer.STATE_STARTED) {
-                    multi.add(new Status(IStatus.ERROR, Activator.PLUGIN_ID, Messages.errorPublishRemoteServerNotStarted));
-                } else {
+                if (getServer().getServerState() == IServer.STATE_STARTED) {
                     multi.add(new Status(IStatus.ERROR, Activator.PLUGIN_ID, Messages.errorPublishJMX));
                 }
                 return; // returning will leave the server in republish state so that the publish can occur when a connection becomes available


### PR DESCRIPTION
Fixes #12

The following message suggests starting the remote server in order to publish but remote start is not supported so remove the message. The server will be in republish state.

"The server needs to be started so that you can publish. Start the server and publish again."