### PR TITLE
Issue #26: fix com.ibm.ws.st.liberty.tools.base feature

### DIFF
--- a/dev/com.ibm.ws.st.liberty.tools.base/feature.xml
+++ b/dev/com.ibm.ws.st.liberty.tools.base/feature.xml
@@ -18,8 +18,9 @@
    </license>
 
    <requires>
-      <import feature="com.ibm.xwt.dde.feature" version="1.0.600.qualifier" match="greaterOrEqual"/>
-      <import feature="com.ibm.ws.st.was.tools.common.core" version="1.0.0.qualifier" match="greaterOrEqual"/>
+      <import feature="com.ibm.xwt.dde.feature" version="1.0.600" match="greaterOrEqual"/>
+      <import feature="com.ibm.ws.st.was.tools.common.core" version="1.0.0" match="greaterOrEqual"/>
+      <import feature="com.ibm.ws.st.was.tools.common.ui" version="1.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
Fixes #26

- A requires is missing for the common ui feature
- For the requires the versions have .qualifier on the end which should not be there