### PR TITLE
[29] Add an error message when a module fails to publish

### DIFF
--- a/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/JEEPublisher.java
+++ b/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/JEEPublisher.java
@@ -145,6 +145,7 @@ public class JEEPublisher extends ApplicationPublisher {
         IModule[] module = unit.getModule();
         int size = module.length;
         List<IStatus> status = new ArrayList<IStatus>();
+
         if (ServerBehaviourDelegate.ADDED == unit.getDeltaKind()) {
             if (Trace.ENABLED)
                 Trace.trace(Trace.INFO, "Module added: " + unit.getModuleName());

--- a/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/JEEPublisher.java
+++ b/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/JEEPublisher.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.jee.core.internal;
 
@@ -145,7 +145,6 @@ public class JEEPublisher extends ApplicationPublisher {
         IModule[] module = unit.getModule();
         int size = module.length;
         List<IStatus> status = new ArrayList<IStatus>();
-
         if (ServerBehaviourDelegate.ADDED == unit.getDeltaKind()) {
             if (Trace.ENABLED)
                 Trace.trace(Trace.INFO, "Module added: " + unit.getModuleName());
@@ -165,7 +164,12 @@ public class JEEPublisher extends ApplicationPublisher {
                     if (jeeModule.isBinary() || JST_WEBFRAGMENT.equals(moduleTypeId)) {
                         publishJar(kind, unit.getDeltaKind(), module, jeeModule.isBinary(), helper, status, monitor);
                     } else {
-                        publishDir(kind, unit.getDeltaKind(), module, getDeployPath(module, false), helper, status, monitor);
+                        try {
+                            publishDir(kind, unit.getDeltaKind(), module, getDeployPath(module, false), helper, status, monitor);
+                        } catch (NullPointerException e) {
+                            status.add(new Status(IStatus.ERROR, Activator.PLUGIN_ID, NLS.bind(Messages.errorPublishingModule, module[size - 1])));
+                            e.printStackTrace();
+                        }
                     }
                 } else if (module[size - 1] instanceof DeletedModule) {
                     boolean skipDelete = false;

--- a/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/Messages.java
+++ b/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/Messages.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.jee.core.internal;
 
@@ -25,6 +25,7 @@ public class Messages extends NLS {
     public static String errorNotSupportedModuleInEAR;
     public static String errorEARMissingRequiredModules;
     public static String errorGettingModulesInEAR;
+    public static String errorPublishingModule;
     public static String warningAppIsOnServer;
     public static String errorGenLooseConfigXML;
     public static String errorSharedLibProjectInfoIncomplete;

--- a/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/Messages.properties
+++ b/dev/com.ibm.ws.st.jee.core/src/com/ibm/ws/st/jee/core/internal/Messages.properties
@@ -30,6 +30,7 @@ errorEARSpecLevel=Enterprise applications must be at the Java EE 6.0 specificati
 errorNotSupportedModuleInEAR=Enterprise applications may only contain Web, EJB, Application Client, or Connector modules and utility jars.
 errorEARMissingRequiredModules=Cannot add an EAR project to the server unless it contains a Web, EJB, Application Client, or Connector module.
 errorGettingModulesInEAR=Modules cannot be retrieved from the enterprise application. Check the deployment assembly for errors or warnings.
+errorPublishingModule=The module {0} failed to publish on the server.
 warningAppIsOnServer={0} is on the server already. If you add it to the server, the application that is already on the server will be overridden.
 taskRemoveExteneralApp=Removing existing application {0}.
 


### PR DESCRIPTION
When a module fails to publish in OLT, only a NPE will be thrown,
without any further useful information being shown. To fix this, I've
surrounded the function that throws the NPE with a try/catch and when an
NPE is caught, a message and a stack trace will be printed out.