### PR TITLE
Update top level feature name to Open Liberty Tools

### DIFF
--- a/dev/com.ibm.ws.st.liberty.tools/feature.properties
+++ b/dev/com.ibm.ws.st.liberty.tools/feature.properties
@@ -1,7 +1,7 @@
 # NLS_ENCODING=UNICODE
 # NLS_MESSAGEFORMAT_NONE
 
-featureName=WebSphere\u00ae Application Server Liberty Tools
+featureName=Open Liberty Tools
 
 # do not translate value - just change to point to a locale-specific HTML page
 licenseURL=license.html


### PR DESCRIPTION
PR for issue #38:

The top level feature says "WebSphere Application Server Liberty Tools". Change it to "Open Liberty Tools" so that it's more clear when being installed alongside WDT.