### PR TITLE
Issue #80: support bootstrap properties/file and server.env file

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/plugin.xml
+++ b/dev/com.ibm.etools.maven.liberty.integration/plugin.xml
@@ -25,6 +25,7 @@
 	<extension point="com.ibm.ws.st.ui.customServerConfig">
 		<handler class="com.ibm.etools.maven.liberty.integration.ui.internal.CustomServerConfig" />
 	</extension>
+	
     <extension point="com.ibm.ws.st.core.customServerVariables">
     	<handler class="com.ibm.etools.maven.liberty.integration.internal.CustomServerVariablesHandler" />
 	</extension>
@@ -65,9 +66,6 @@
       </includes>
     </viewerContentBinding>
   </extension>
-    <extension point="com.ibm.ws.st.core.customServerVariables">
-    	<handler class="com.ibm.etools.maven.liberty.integration.internal.CustomServerVariablesHandler" />
-	</extension>
 
 	<extension point="com.ibm.ws.st.common.core.ext.serverTypeExtension">
       <serverTypeExtension

--- a/dev/com.ibm.ws.st.liberty.gradle/plugin.xml
+++ b/dev/com.ibm.ws.st.liberty.gradle/plugin.xml
@@ -14,6 +14,7 @@
 	<extension point="com.ibm.ws.st.ui.customServerConfig">
 		<handler class="com.ibm.ws.st.liberty.gradle.ui.internal.CustomServerConfig" />
 	</extension>
+	
     <extension point="com.ibm.ws.st.core.customServerVariables">
     	<handler class="com.ibm.ws.st.liberty.gradle.internal.CustomServerVariablesHandler" />
 	</extension>
@@ -54,10 +55,7 @@
       </includes>
     </viewerContentBinding>
   </extension>
-    <extension point="com.ibm.ws.st.core.customServerVariables">
-    	<handler class="com.ibm.ws.st.liberty.gradle.internal.CustomServerVariablesHandler" />
-	</extension>
-
+  
 	<extension point="com.ibm.ws.st.common.core.ext.serverTypeExtension">
       <serverTypeExtension
          id="com.ibm.ws.st.liberty.gradle.libertyGradleServerType"

--- a/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/CustomServerVariablesHandler.java
+++ b/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/CustomServerVariablesHandler.java
@@ -43,13 +43,13 @@ public class CustomServerVariablesHandler extends AbstractCustomServerVariablesH
     @Override
     protected void addInlineVars(IProject project, ConfigVars configVars, LibertyBuildPluginConfiguration libertyBuildProjectConfiguration) {
 
-        URI pomURI = obtainPomURI(project);
-        if (libertyBuildProjectConfiguration != null && pomURI != null) {
+        URI buildScriptURI = obtainBuildScriptURI(project);
+        if (libertyBuildProjectConfiguration != null && buildScriptURI != null) {
             // Load in-line bootstrap variables (when applicable)
             // Overlapping variables from server.env file will be overridden (in-line bootstrap variables have higher priority)
             // Overlapping variables from bootstrap.properties file will be overridden (in-line bootstrap variables have higher priority)
             // Note that in practice overlapping between bootstrap.properties file and in-line bootstrap variables should not happen
-            DocumentLocation documentLocation = DocumentLocation.createDocumentLocation(pomURI, DocumentLocation.Type.BOOTSTRAP);
+            DocumentLocation documentLocation = DocumentLocation.createDocumentLocation(buildScriptURI, DocumentLocation.Type.BOOTSTRAP);
             Map<String, String> bootstrapProperties = libertyBuildProjectConfiguration.getBootstrapProperties();
             Iterator<String> iterator = bootstrapProperties.keySet().iterator();
             while (iterator.hasNext()) {
@@ -60,13 +60,13 @@ public class CustomServerVariablesHandler extends AbstractCustomServerVariablesH
         }
     }
 
-    private URI obtainPomURI(IProject project) {
+	private URI obtainBuildScriptURI(IProject project) {
         if (project == null)
             return null;
         try {
-            return new URI(project.getLocationURI().toString() + "/pom.xml");
+            return new URI(project.getLocationURI().toString() + "/" + LibertyGradleConstants.GRADLE_BUILD_SCRIPT);
         } catch (URISyntaxException exception) {
-            Trace.logError("Could not obtain URI to pom.xml in project " + project.getName(), exception);
+            Trace.logError("Could not obtain URI to " + LibertyGradleConstants.GRADLE_BUILD_SCRIPT + " in project " + project.getName(), exception);
         }
         return null;
     }

--- a/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradleConstants.java
+++ b/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradleConstants.java
@@ -12,8 +12,8 @@
 package com.ibm.ws.st.liberty.gradle.internal;
 
 public class LibertyGradleConstants {
-
-    public static final String POM_FILE_NAME = "pom.xml";
+	
+	public static final String GRADLE_BUILD_SCRIPT = "build.gradle";
 
     public enum ProjectType {
         STANDARD


### PR DESCRIPTION
Fixes #80

Support bootstrap properties variables supplied directly in the build.gradle file as well as in the bootstrap.properties file and env variables in the server.env file.

Also fixed duplicate declarations of the custom server variables extensions (both Gradle and Maven) and cleaned up GradleProjectInspector.getGradleProject.