### PR TITLE
Issue #98: make sure the application update trigger is set to mbean

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenServer.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenServer.java
@@ -11,26 +11,11 @@
 
 package com.ibm.etools.maven.liberty.integration.servertype.internal;
 
-import org.eclipse.wst.server.core.IServer;
-
-import com.ibm.ws.st.common.core.ext.internal.servertype.AbstractServerExtension;
-import com.ibm.ws.st.core.internal.WebSphereServer;
+import com.ibm.ws.st.liberty.buildplugin.integration.servertype.internal.AbstractLibertyBuildPluginServer;
 
 /**
  * Liberty Maven Server Implementation
  */
-
-@SuppressWarnings("restriction")
-public class LibertyMavenServer extends AbstractServerExtension {
-
-    // In order to use the existing loose config publishing mechanism, the isLocalSetup needs to be
-    // true, otherwise it attempts to do remote publishing
-    @Override
-    public Boolean isLocalSetup(IServer server) {
-        if (server != null) {
-            WebSphereServer wsServer = server.getAdapter(WebSphereServer.class);
-            return new Boolean(wsServer.isLocalHost());
-        }
-        return null;
-    }
+public class LibertyMavenServer extends AbstractLibertyBuildPluginServer {
+    // No changes from the base
 }

--- a/dev/com.ibm.ws.st.common.core.ext/src/com/ibm/ws/st/common/core/ext/internal/servertype/AbstractServerExtension.java
+++ b/dev/com.ibm.ws.st.common.core.ext/src/com/ibm/ws/st/common/core/ext/internal/servertype/AbstractServerExtension.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.st.common.core.ext.internal.servertype;
@@ -113,4 +113,14 @@ public abstract class AbstractServerExtension {
     public Boolean isLocalSetup(IServer server) {
         return null;
     }
+
+    /**
+     * Perform any additional work on a server configuration change
+     *
+     * @param server
+     */
+    public void serverConfigChanged(IServer server, IProgressMonitor monitor) {
+        // Do nothing by default
+    }
+
 }

--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/ConfigurationResourceChangeListener.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/ConfigurationResourceChangeListener.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.internal;
 
@@ -266,7 +266,7 @@ public class ConfigurationResourceChangeListener implements IResourceChangeListe
             WebSphereServer ws = WebSphereUtil.getWebSphereServer(server);
             if (ws != null) {
                 if (ws.isLocalSetup())
-                    ws.addLocalConnectorFeature(null);
+                    ws.serverConfigChanged(null);
                 ws.getWebSphereServerBehaviour().startAutoConfigSyncJob();
             }
 

--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereServer.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereServer.java
@@ -1670,4 +1670,9 @@ public class WebSphereServer extends ServerDelegate implements IURLProvider, IAd
         }
     }
 
+    public void serverConfigChanged(IProgressMonitor monitor) {
+        AbstractServerExtension serverExt = getServerTypeExtension();
+        serverExt.serverConfigChanged(getServer(), monitor);
+    }
+
 }

--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereUtil.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereUtil.java
@@ -778,4 +778,26 @@ public class WebSphereUtil {
         }
         return name;
     }
+
+    /**
+     * Get the WebSphereServer given the IServer
+     * 
+     * @param server The IServer - should not be null
+     * @return The WebSphereServer or null if the server is not a WebSphere server
+     */
+    public static WebSphereServer getWebSphereServer(IServer server) {
+        if (server == null) {
+            if (Trace.ENABLED) {
+                Trace.trace(Trace.WARNING, "The server should not be null.");
+            }
+            return null;
+        }
+        WebSphereServer wsServer = server.getAdapter(WebSphereServer.class);
+        if (wsServer == null) {
+            if (Trace.ENABLED) {
+                Trace.trace(Trace.WARNING, "The server is not a WebSphereServer as expected: " + server.getName());
+            }
+        }
+        return wsServer;
+    }
 }

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/servertype/internal/AbstractLibertyBuildPluginServer.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/servertype/internal/AbstractLibertyBuildPluginServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,45 +8,39 @@
  * Contributors:
  * IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-package com.ibm.ws.st.core.internal;
-
-import java.util.HashMap;
-import java.util.Map;
+package com.ibm.ws.st.liberty.buildplugin.integration.servertype.internal;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.wst.server.core.IServer;
 
 import com.ibm.ws.st.common.core.ext.internal.servertype.AbstractServerExtension;
+import com.ibm.ws.st.core.internal.WebSphereServer;
+import com.ibm.ws.st.core.internal.WebSphereUtil;
 
 /**
- *
+ * Liberty Build Plugin Server Implementation
  */
-public class BaseLibertyServerExtension extends AbstractServerExtension {
-    public Map<String, String> getServiceInfo() {
-        return new HashMap<String, String>();
-    }
+@SuppressWarnings("restriction")
+public class AbstractLibertyBuildPluginServer extends AbstractServerExtension {
 
-    /** {@inheritDoc} */
+    // In order to use the existing loose config publishing mechanism, the isLocalSetup needs to be
+    // true, otherwise it attempts to do remote publishing
     @Override
-    public String getServerDisplayName(IServer server) {
+    public Boolean isLocalSetup(IServer server) {
         WebSphereServer wsServer = WebSphereUtil.getWebSphereServer(server);
         if (wsServer != null) {
-            return wsServer.getServerName();
+            return new Boolean(wsServer.isLocalHost());
         }
         return null;
     }
 
-    /** {@inheritDoc} */
+    // Make sure the localConnector feature is enabled and the application
+    // update trigger is set to mbean
     @Override
     public void serverConfigChanged(IServer server, IProgressMonitor monitor) {
-        // By default, only add the localConnector feature as the user may have
-        // changed the application update trigger setting on purpose.  Some
-        // server extensions may want to override this default behaviour.
         WebSphereServer wsServer = WebSphereUtil.getWebSphereServer(server);
         if (wsServer != null) {
-            wsServer.addLocalConnectorFeature(monitor);
+            wsServer.ensureLocalConnectorAndAppMBeanConfig(monitor);
         }
     }
-
 }

--- a/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/servertype/internal/LibertyGradleServer.java
+++ b/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/servertype/internal/LibertyGradleServer.java
@@ -11,26 +11,11 @@
 
 package com.ibm.ws.st.liberty.gradle.servertype.internal;
 
-import org.eclipse.wst.server.core.IServer;
-
-import com.ibm.ws.st.common.core.ext.internal.servertype.AbstractServerExtension;
-import com.ibm.ws.st.core.internal.WebSphereServer;
+import com.ibm.ws.st.liberty.buildplugin.integration.servertype.internal.AbstractLibertyBuildPluginServer;
 
 /**
  * Liberty Gradle Server Implementation
  */
-
-@SuppressWarnings("restriction")
-public class LibertyGradleServer extends AbstractServerExtension {
-
-    // In order to use the existing loose config publishing mechanism, the isLocalSetup needs to be
-    // true, otherwise it attempts to do remote publishing
-    @Override
-    public Boolean isLocalSetup(IServer server) {
-        if (server != null) {
-            WebSphereServer wsServer = server.getAdapter(WebSphereServer.class);
-            return new Boolean(wsServer.isLocalHost());
-        }
-        return null;
-    }
+public class LibertyGradleServer extends AbstractLibertyBuildPluginServer {
+    // No changes from the base
 }


### PR DESCRIPTION
Fixes #98 

For Maven and Gradle make sure that after a change to the src server
configuration, the target or build server configuration is fixed up
again with the localConnector feature enabled and the application update
trigger set to mbean.