### PR TITLE
Issue 100: refresh user directory after src config changes copied over

### DIFF
--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/manager/internal/AbstractLibertyManager.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/manager/internal/AbstractLibertyManager.java
@@ -295,6 +295,18 @@ public abstract class AbstractLibertyManager implements IResourceChangeListener,
             IPath location = project.getLocation();
             buildPluginHelper.updateSrcConfig(location, config, monitor);
 
+            // Any changes to the src server config have been copied over to the
+            // user directory so make sure it is refreshed
+            UserDirectory userDir = wsServer.getServerInfo().getUserDirectory();
+            final IProject userDirProject = userDir.getProject();
+            if (userDirProject != null && userDirProject.isAccessible()) {
+                try {
+                    userDirProject.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+                } catch (Exception e) {
+                    Trace.logError("Refreshing user directory project failed", e);
+                }
+            }
+
             // Change the server to republish state so it will process the changed file on the next publish operation
             WebSphereServerBehaviour wsb = wsServer.getWebSphereServerBehaviour();
             wsb.setWebSphereServerPublishState(IServer.PUBLISH_STATE_INCREMENTAL);


### PR DESCRIPTION
Fixes #100 

Make sure the user directory is refreshed after any changed src server configuration files are copied over.