### PR TITLE
Fix divide by zero in server configuration refresh job

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Activator.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/Activator.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.internal;
 
@@ -440,23 +440,25 @@ public class Activator extends Plugin {
                                     int serverWork = totalWork / serverInfos.size();
                                     for (WebSphereServerInfo info : serverInfos) {
                                         ConfigurationFile[] configFiles = info.getConfigurationFiles();
-                                        int fileWork = serverWork / configFiles.length;
-                                        for (ConfigurationFile file : configFiles) {
-                                            IFile iFile = file.getIFile();
-                                            if (iFile != null) {
-                                                try {
-                                                    // An IFile.touch will tell eclipse that the file has changed so
-                                                    // that it gets revalidated but it does not update the timestamp
-                                                    // on the file.
-                                                    iFile.touch(monitor.newChild(fileWork));
-                                                } catch (CoreException e) {
-                                                    if (Trace.ENABLED) {
-                                                        Trace.trace(Trace.WARNING, "Touch failed on file: " + iFile.getLocation().toOSString(), e);
+                                        if (configFiles.length > 0) {
+                                            int fileWork = serverWork / configFiles.length;
+                                            for (ConfigurationFile file : configFiles) {
+                                                IFile iFile = file.getIFile();
+                                                if (iFile != null) {
+                                                    try {
+                                                        // An IFile.touch will tell eclipse that the file has changed so
+                                                        // that it gets revalidated but it does not update the timestamp
+                                                        // on the file.
+                                                        iFile.touch(monitor.newChild(fileWork));
+                                                    } catch (CoreException e) {
+                                                        if (Trace.ENABLED) {
+                                                            Trace.trace(Trace.WARNING, "Touch failed on file: " + iFile.getLocation().toOSString(), e);
+                                                        }
                                                     }
                                                 }
-                                            }
-                                            if (monitor.isCanceled()) {
-                                                return Status.CANCEL_STATUS;
+                                                if (monitor.isCanceled()) {
+                                                    return Status.CANCEL_STATUS;
+                                                }
                                             }
                                         }
                                     }
@@ -486,6 +488,7 @@ public class Activator extends Plugin {
         emptyContainerExtensions = emptyContainerlist.toArray(new ClasspathExtension[emptyContainerlist.size()]);
 
         checkRuntimeMetadata();
+
     }
 
     @Override


### PR DESCRIPTION
Someone reported seeing a divide by zero error during the runtime configuration file refresh job. They weren't able to reproduce but it appears the problem is caused by a WebSphereServerInfo not containing any references to config files. It's likely a corner case scenario where the user has a server definition in the workspace for a server that no longer exists in the filesystem so it's probably safe enough to just add a check to make sure the server info has some config files references before proceeding.