### PR TITLE
Issue #120: export Liberty Gradle internal package for test use

### DIFF
--- a/dev/com.ibm.ws.st.liberty.gradle/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.st.liberty.gradle/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: com.ibm.ws.st.ui,
  com.ibm.ws.st.core
+Export-Package: com.ibm.ws.st.liberty.gradle.internal;x-internal:=true
 Import-Package: com.ibm.ws.st.liberty.buildplugin.integration.internal,
  com.ibm.ws.st.liberty.buildplugin.integration.manager.internal,
  com.ibm.ws.st.liberty.buildplugin.integration.servertype.internal,


### PR DESCRIPTION
Fixes #120

Export the com.ibm.ws.st.liberty.gradle.internal package as internal for test use.