### PR TITLE
Issue #142: minor test fixes

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/Java2SecurityTests_LooseCfg.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/Java2SecurityTests_LooseCfg.java
@@ -6,14 +6,14 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests;
 
 import java.util.ArrayList;
 
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.runners.AllTests;
 
 import com.ibm.ws.st.core.tests.jee.JEEPublishEarNoDD;
 import com.ibm.ws.st.core.tests.jee.JEEPublishWarDD;
@@ -26,10 +26,13 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 // Run tests with the following properties
-//    -Dwas.runtime.liberty.enableJava2Security=true
-//    -Dwas.runtime.liberty=<runtime location>
-//    -Dliberty.loosecfg=true
-@RunWith(Suite.class)
+// -Dwas.runtime.liberty.enableJava2Security=true
+// -Dwas.runtime.liberty=<runtime location>
+//
+// The following property is set within the test suite but when running
+// the tests individually, also set:
+// -Dliberty.loosecfg=true
+@RunWith(AllTests.class)
 public class Java2SecurityTests_LooseCfg {
     public static TestSuite suite() {
         System.setProperty(ServerTestUtil.LOOSE_CFG_MODE_PROP, "true");

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/AllDockerTests_LooseCfg.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/AllDockerTests_LooseCfg.java
@@ -30,6 +30,10 @@ import junit.framework.TestSuite;
 // -Dwas.runtime.liberty=<runtime location>
 // -Dliberty.servertype=LibertyDocker
 // -Dliberty.loosecfg=true
+//
+// IMPORTANT: when running on Windows or OS X the workspace for the tests
+// must be in the user home directory or another directory that is shared
+// with Docker (this is because loose configuration uses Docker volumes)
 @RunWith(AllTests.class)
 public class AllDockerTests_LooseCfg {
     public static TestSuite suite() {

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/AllJEETests_LooseCfg.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/AllJEETests_LooseCfg.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.jee;
 
@@ -21,9 +21,12 @@ import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-// Run tests with the following properties
-//    -Dwas.runtime.liberty.enableJava2Security=true
-//    -Dwas.runtime.liberty=<location of liberty runtime>
+// Run tests with the following properties:
+// -Dwas.runtime.liberty=<location of liberty runtime>
+//
+// The following property is set within the test suite but when running
+// the tests individually, also set:
+// -Dliberty.loosecfg=true
 @RunWith(AllTests.class)
 public class AllJEETests_LooseCfg {
     public static final String JDK_VERSION_7 = "1.7.0";


### PR DESCRIPTION
Fixes #142

AllJEETests_LooseCfg - remove the instruction to enable Java security

Java2SecurityTests_LooseCfg - should have a @RunWith(AllTests.class)
instead of @RunWith(Suite.class)

AllDockerTests_LooseCfg - add a comment that when running on Windows or
OS X that the workspace must be in the user home directory or another
directory that is shared with Docker