### PR TITLE
Issue #148: Fix server name for Maven/Gradle

### DIFF
--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/servertype/internal/AbstractLibertyBuildPluginServer.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/servertype/internal/AbstractLibertyBuildPluginServer.java
@@ -43,4 +43,13 @@ public class AbstractLibertyBuildPluginServer extends AbstractServerExtension {
             wsServer.ensureLocalConnectorAndAppMBeanConfig(monitor);
         }
     }
+
+    @Override
+    public String getServerDisplayName(IServer server) {
+        WebSphereServer wsServer = WebSphereUtil.getWebSphereServer(server);
+        if (wsServer != null) {
+            return wsServer.getServerName();
+        }
+        return super.getServerDisplayName(server);
+    }
 }


### PR DESCRIPTION
Fixes #148

Currently for a Maven or Gradle server the server shows as follows in the Servers view:
rest [rest] [Stopped]

This is confusing because when the server is started, the console view shows:

The server defaultServer is ready to run a smarter planet.

In the Servers view it should have:
rest [defaultServer] [Stopped]

This would make it consistent with non Maven/Gradle servers as well.