### PR TITLE
Issue #159: Add -DskipLibertyPackage=true to all Maven goals

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,7 +81,7 @@ public class LibertyMaven implements ILibertyBuildPluginImpl {
         ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
         ILaunchConfigurationType launchConfigurationType = launchManager.getLaunchConfigurationType("org.eclipse.m2e.Maven2LaunchConfigurationType");
 
-        String goal = specifiedGoal + " -DskipTests=true";
+        String goal = specifiedGoal + " -DskipTests=true -DskipLibertyPackage=true";
         try {
             Trace.trace(Trace.INFO, "Running maven goal \'" + goal + "\' with working directory: " + workingDir.toOSString());
             ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance((IContainer) null, workingDir.lastSegment());

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,7 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                             int publishUnitKind = unit.getDeltaKind();
                             if (!isLC && "ear".equals(projectType) && (ServerBehaviourDelegate.ADDED == publishUnitKind || ServerBehaviourDelegate.CHANGED == publishUnitKind)) {
 
-                                publishOnParent(wsServer, moduleProject, config, "package -DskipLibertyPackage=true",
+                                publishOnParent(wsServer, moduleProject, config, "package",
                                                 kind, unit, mStatus, monitor);
 
                                 String pathToPublishedModule = getPathToPublishedModule(config);
@@ -267,7 +267,7 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                                         LibertyMaven.runMavenGoal(moduleProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);
                                     }
 
-                                    String installGoal = "liberty:install-apps -DskipLibertyPackage=true";
+                                    String installGoal = "liberty:install-apps";
                                     Trace.trace(Trace.INFO, "Running " + installGoal + " goal on project: " + mappedProject.getName());
                                     LibertyMaven.runMavenGoal(mappedProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);
                                     wsServer.ensureLocalConnectorAndAppMBeanConfig(monitor);


### PR DESCRIPTION
Fixes #159 

Add -DskipLibertyPackage=true the general code to run a Maven goal and remove it anywhere it is set explicitly.