### PR TITLE
Issue #164: Make docker tests more flexible so they can run in parallel

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/StandaloneLibertyTestExt.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/StandaloneLibertyTestExt.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests;
 
@@ -123,6 +123,12 @@ public class StandaloneLibertyTestExt implements TestBaseInterface {
     /** {@inheritDoc} */
     @Override
     public void cleanUp() {
+        WLPCommonUtil.cleanUp();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void cleanUp(IServer server) {
         WLPCommonUtil.cleanUp();
     }
 

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/TestBaseInterface.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/TestBaseInterface.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests;
 
@@ -29,6 +29,11 @@ public interface TestBaseInterface {
      * Cleans up the test workspace
      */
     public void cleanUp();
+
+    /**
+     * Clean up the test workspace
+     */
+    public void cleanUp(IServer server);
 
     /**
      * Get the base URL for the server (e.g. http://localhost:9080)

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/ToolsTestBase.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/ToolsTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -651,7 +651,7 @@ public abstract class ToolsTestBase extends TestCase {
     }
 
     protected void cleanUp() {
-        ServerTestUtil.cleanUp();
+        ServerTestUtil.cleanUp(server);
     }
 
 //    protected static void safePublishIncremental(IServer server) throws CoreException {

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/DockerServerTest.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/DockerServerTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.docker;
 
@@ -78,7 +78,8 @@ public class DockerServerTest extends ToolsTestBase {
         }
 
         // get the featurelist from the runtime in the docker container
-        String containerName = DockerTestUtil.getDockerContainerName();
+        String containerName = DockerTestUtil.getContainerName(server);
+        assertNotNull("The container name for the " + server.getName() + " server should not be null.", containerName);
         BaseDockerContainer container = DockerTestUtil.getExistingContainer(DockerTestUtil.getDockerMachine(), containerName);
 
         // assert that only one restConnector feature is configured

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/LibertyDockerTestExt.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/docker/LibertyDockerTestExt.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.docker;
 
@@ -70,7 +70,7 @@ public class LibertyDockerTestExt extends StandaloneLibertyTestExt {
         }
 
         if (container == null) {
-            container = DockerTestUtil.getDockerContainer();
+            container = DockerTestUtil.getDockerContainer(machine);
         }
         assertNotNull("The docker container is null, this typically happens if the docker-machine isn't running", container);
 
@@ -265,12 +265,23 @@ public class LibertyDockerTestExt extends StandaloneLibertyTestExt {
     @Override
     public void cleanUp() {
         WLPCommonUtil.cleanUp();
+    }
 
-        //Only remove the container if a new one was created during the test
+    @Override
+    public void cleanUp(IServer server) {
+        // Get the container name from the server before the server is cleaned up
+        String containerName = null;
         if (!DockerTestUtil.isContainerSpecified()) {
-            String containerName = DockerTestUtil.getDockerContainerName();
+            containerName = DockerTestUtil.getContainerName(server);
+        }
+
+        WLPCommonUtil.cleanUp();
+
+        // Remove the container if a new one was created during test (it was not
+        // specified in the properties)
+        if (containerName != null) {
             try {
-                DockerTestUtil.getDockerMachine().removeContainer(containerName);
+                DockerTestUtil.getDockerMachine().removeContainer(containerName, true);
             } catch (Exception e) {
                 Trace.logError("Error removing the container: " + containerName, e);
             }

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishEarBase.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishEarBase.java
@@ -1,22 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
-/*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.jee;
 
@@ -27,7 +17,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 
 import com.ibm.ws.st.core.tests.util.ServerTestUtil;
-import com.ibm.ws.st.core.tests.util.WLPCommonUtil;
 
 @RunWith(AllTests.class)
 public abstract class JEEPublishEarBase extends JEETestBase {
@@ -271,7 +260,7 @@ public abstract class JEEPublishEarBase extends JEETestBase {
         removeApp("Web1EAR", 2500);
         removeApp("Web2EAR", 2500);
         stopServer();
-        WLPCommonUtil.cleanUp();
+        cleanUp();
         wait("Ending test: " + getClassName() + "\n", 5000);
     }
 

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishEarRemap.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishEarRemap.java
@@ -1,26 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
-/*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.jee;
-
-import junit.framework.TestSuite;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -28,8 +16,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 
-import com.ibm.ws.st.core.tests.util.WLPCommonUtil;
 import com.ibm.ws.st.tests.common.util.TestCaseDescriptor;
+
+import junit.framework.TestSuite;
 
 @TestCaseDescriptor(description = "Test publish of enterprise app with EJB (defect 115237)", isStable = true)
 @RunWith(AllTests.class)
@@ -100,7 +89,7 @@ public class JEEPublishEarRemap extends JEETestBase {
     public void doTearDown() throws Exception {
         removeApp("EJBApp", 2500);
         stopServer();
-        WLPCommonUtil.cleanUp();
+        cleanUp();
         wait("Ending test: " + getClassName() + "\n", 5000);
     }
 

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishWarBase.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/JEEPublishWarBase.java
@@ -1,22 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
-/*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.jee;
 
@@ -27,7 +17,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 
 import com.ibm.ws.st.core.tests.util.ServerTestUtil;
-import com.ibm.ws.st.core.tests.util.WLPCommonUtil;
 
 @RunWith(AllTests.class)
 public abstract class JEEPublishWarBase extends JEETestBase {
@@ -268,7 +257,7 @@ public abstract class JEEPublishWarBase extends JEETestBase {
         removeApp("Web1", 2500);
         removeApp("Web2", 2500);
         stopServer();
-        WLPCommonUtil.cleanUp();
+        cleanUp();
         wait("Ending test: " + getClassName() + "\n", 5000);
     }
 

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/util/ServerTestUtil.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/util/ServerTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -563,6 +563,11 @@ public class ServerTestUtil {
     public static void cleanUp() {
         TestBaseInterface testExt = getTestBaseExtension();
         testExt.cleanUp();
+    }
+
+    public static void cleanUp(IServer server) {
+        TestBaseInterface testExt = getTestBaseExtension();
+        testExt.cleanUp(server);
     }
 
     public static IProject getProject(String projectName) {


### PR DESCRIPTION
Fixes #164 

Make docker tests more flexible so they can run in parallel by:
- generating a random container name that is not already used
- selecting a random remote host from a list