### PR TITLE
Issue #198: Resolve jsfContainer feature instead of hard coding version

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/ToolsTestBase.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/ToolsTestBase.java
@@ -221,6 +221,23 @@ public abstract class ToolsTestBase extends TestCase {
         return feature != null && !feature.isEmpty();
     }
 
+    /*
+     * Resolve a feature. Ensures the runtime supports the feature
+     * and if the feature name passed in has no version then it returns
+     * the latest version of that feature.
+     *
+     * If the feature cannot be resolved it returns null.
+     */
+    protected String resolveFeature(String featureName) {
+        WebSphereRuntime wsRuntime = getWebSphereRuntime();
+        FeatureSet features = wsRuntime.getInstalledFeatures();
+        String feature = features.resolve(featureName);
+        if (feature != null && feature.isEmpty()) {
+            feature = null;
+        }
+        return feature;
+    }
+
     protected static WebSphereRuntime getWebSphereRuntime() {
         if (runtime == null)
             throw new NullPointerException("Runtime should not be null.");

--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/featureDetection/AlternativeFeatureTest.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/jee/featureDetection/AlternativeFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ public class AlternativeFeatureTest extends ToolsTestBase {
     private static final String FACES_CONFIG_SERVLET_NAME = "TestJSFFaces/JSFFacesServlet";
     private static final String FACES_CONFIG_SERVLET_BODY = "Hello from JSFFacesServlet";
 
-    private static final String JSF_CONTAINER_VERSION = "2.2";
+    private static final String JSF_CONTAINER_FEATURE = "jsfContainer";
 
     @Test
     public void test01_doSetup() throws Exception {
@@ -78,8 +78,9 @@ public class AlternativeFeatureTest extends ToolsTestBase {
 
         // Test that jsf is NOT added in this case, since it should
         // see jsfContainer as equivalent.
-        if (runtimeSupportsFeature("jsfContainer-" + JSF_CONTAINER_VERSION)) {
-            addFeatures(new String[] { "jsfContainer-" + JSF_CONTAINER_VERSION });
+        String feature = resolveFeature(JSF_CONTAINER_FEATURE);
+        if (feature != null) {
+            addFeatures(new String[] { feature });
 
             addApp(JSF_FACET_PROJECT_NAME);
             checkFeatures(new String[] { "jsfContainer" }, new String[] { "jsf" });
@@ -114,8 +115,9 @@ public class AlternativeFeatureTest extends ToolsTestBase {
 
         // Test that jsf is NOT added in this case, since it should
         // see jsfContainer as equivalent.
-        if (runtimeSupportsFeature("jsfContainer-" + JSF_CONTAINER_VERSION)) {
-            addFeatures(new String[] { "jsfContainer-" + JSF_CONTAINER_VERSION });
+        String feature = resolveFeature(JSF_CONTAINER_FEATURE);
+        if (feature != null) {
+            addFeatures(new String[] { feature });
 
             addApp(JSF_FACES_CONFIG_PROJECT_NAME);
             checkFeatures(new String[] { "jsfContainer" }, new String[] { "jsf" });

--- a/dev/com.ibm.ws.st.core_tests/resources/FeatureTesting/AlternativeFeatureTest/TestJSFFaces/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/FeatureTesting/AlternativeFeatureTest/TestJSFFaces/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <runtime name="17.0.0.3"/>
+  <runtime name="Liberty_Tools_Runtime"/>
   <fixed facet="wst.jsdt.web"/>
   <fixed facet="java"/>
   <fixed facet="jst.web"/>

--- a/dev/com.ibm.ws.st.core_tests/resources/FeatureTesting/AlternativeFeatureTest/TestJSFFacet/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/FeatureTesting/AlternativeFeatureTest/TestJSFFacet/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <runtime name="17.0.0.3"/>
+  <runtime name="Liberty_Tools_Runtime"/>
   <fixed facet="wst.jsdt.web"/>
   <fixed facet="java"/>
   <fixed facet="jst.web"/>


### PR DESCRIPTION
Fixes #198 

Instead of hard coding the version, resolve the jsfContainer feature to the latest version supported by the runtime.  Also fix up the targeted runtime on the projects.