### PR TITLE
Issue 203: support new list variable syntax

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/validation/VariableValidationTest.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/validation/VariableValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,6 +57,7 @@ public class VariableValidationTest extends ValidationTestBase {
         testSuite.addTest(TestSuite.createTest(VariableValidationTest.class, "implicitVarValue"));
         testSuite.addTest(TestSuite.createTest(VariableValidationTest.class, "varRefInvalidValue"));
         testSuite.addTest(TestSuite.createTest(VariableValidationTest.class, "testServerEnv"));
+        testSuite.addTest(TestSuite.createTest(VariableValidationTest.class, "varList"));
         testSuite.addTest(TestSuite.createTest(VariableValidationTest.class, "doTearDown"));
 
         return testSuite;
@@ -259,6 +260,19 @@ public class VariableValidationTest extends ValidationTestBase {
                 FileUtil.deleteDirectory(etcDir.getAbsolutePath(), true);
             }
         }
+    }
+
+    @Test
+    public void varList() throws Exception {
+        // Test that the ${list(varname)} syntax is handled properly
+        String serverName = "varList";
+        setupRuntimeServer(RESOURCE_PATH, serverName);
+        IFile file = getServerFile(serverName, "server.xml");
+        ValidatorMessage[] messages = TestUtil.validate(file);
+        checkMessageCount(messages, 1);
+        checkMessage(messages[0], NLS.bind(Messages.unresolvedPropertyValue, new String[] { "filesetRef", "library", "filesetsBC" }),
+                     serverName + "/" + file.getName(), 27);
+        deleteRuntimeServer(serverName);
     }
 
     @Test

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/varList/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/varList/server.xml
@@ -1,0 +1,28 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Test list variables">
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+
+    <httpEndpoint httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint"/>
+
+    <applicationManager autoExpand="true"/>
+    
+    <fileset id="filesetA"></fileset>
+    <fileset id="filesetB"></fileset>
+    
+    <variable name="filesetsAB" value="filesetA, filesetB"/>
+
+    <library apiTypeVisibility="spec,ibm-api,api" filesetRef="${list(filesetsAB)}" id="libAB" name="libAB"></library>
+    <library apiTypeVisibility="spec,ibm-api,api" filesetRef="${list(filesetsBC)}" id="libBC" name="libBC"></library>
+</server>


### PR DESCRIPTION
Fixes #203

The Open Liberty runtime has added the following variable reference syntax to allow variables to be interpreted as lists:

${list(varName)}

Where 'list' is all lower case (case sensitive).

Example:

\<variable name="valuesVariable" value="value1, value2, value3"/\>
\<someElement values="${list(valuesVariable)}"/\>

The tools need to recognize this syntax so that it treats varName as the variable name instead of list(varName).

Handle in the same place that expressions are handled in ConfigVars.resolve (expressions are: ${\<operand\>\<operator\>\<operand\>}, e.g. ${HTTP_port_base+1}).