### PR TITLE
Issue #224: fix JAXWSEJBSample so the sample compiles

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/samples/JAXWSEJBSample.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/samples/JAXWSEJBSample.java
@@ -6,14 +6,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.tests.samples;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import junit.framework.TestSuite;
 
 import org.eclipse.core.runtime.Path;
 import org.junit.Test;
@@ -22,6 +20,8 @@ import org.junit.runners.AllTests;
 
 import com.ibm.ws.st.core.tests.util.WLPCommonUtil;
 import com.ibm.ws.st.tests.common.util.TestCaseDescriptor;
+
+import junit.framework.TestSuite;
 
 /**
  *
@@ -72,16 +72,16 @@ public class JAXWSEJBSample extends SampleTestBase {
         init();
 
         //create liberty runtime. Runtime name initialized from super class
-        createRuntime();
+        createRuntime("Liberty Runtime");
 
         //Create server
         createServer();
 
-        //Not sure why we need to create vm ?????
-        createVM(JDK_NAME);
+        //Create a vm with the name expected by the sample test case
+        createVM("jdk8");
 
         importProjects(new Path("sampleTesting" + "/" + SAMPLE_TEST_NAME + "/ws"), new String[] { "JAXWSEJBSample", "JAXWSEJBSample_WEB", "AnEJBWebServices",
-                                                                                                 "AnEJBWebServicesWithHandler" });
+                                                                                                  "AnEJBWebServicesWithHandler" });
 
         //start server and Add the application
         startServer();


### PR DESCRIPTION
Fix the JAXWSEJBSample test case so that the sample compiles.  The name of the runtime and JDK that are created needs to be fixed to match what is expected in the test case.

Fixes #224 