### PR TITLE
255 Call init on fallback publisher

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/ServerExtensionWrapper.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/ServerExtensionWrapper.java
@@ -269,6 +269,7 @@ public class ServerExtensionWrapper {
                         return null;
                     }
                 };
+                publishDelegate.init(this);
             }
         }
         return publishDelegate;

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -23,3 +23,6 @@ eclipse.temp.folder=/target_platform/prereqs/temp/plugins
 ant.prereqslib.folder=/ant_build/prereqs/lib
 ant.artifacts.folder=ant_build/artifacts/
 
+# Force use of TLS 1.2
+systemProp.com.ibm.jsse2.overrideDefaultTLS=true
+org.gradle.daemon=false


### PR DESCRIPTION
Fixes #255

If a fallback publisher is created then init should be called on it otherwise wrapper will be null leading to various NPEs.