### PR TITLE
264 Remove jdk check for Windows OS logon

### DIFF
--- a/dev/com.ibm.ws.st.common.ui/src/com/ibm/ws/st/common/ui/internal/composite/AbstractRemoteServerStartupComposite.java
+++ b/dev/com.ibm.ws.st.common.ui/src/com/ibm/ws/st/common/ui/internal/composite/AbstractRemoteServerStartupComposite.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corporation and others.
+ * Copyright (c) 2014, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.common.ui.internal.composite;
 
@@ -862,15 +862,8 @@ public abstract class AbstractRemoteServerStartupComposite extends BaseRemoteCom
     protected String validateOSLogon() {
         String msg = null;
         if (isOSLogonBtn != null && isOSLogonBtn.getSelection()) {
-            // RTC 105335: block Windows OS login authentication when
-            // using non-IBM JRE since remote utility does not support this scenario
             if (Trace.ENABLED) {
                 Trace.trace(Trace.INFO, "isIBMJRE=" + isIBMJRE);
-            }
-
-            if (!isIBMJRE && isWindowsBtn != null && isWindowsBtn.getSelection()) {
-                msg = Messages.E_RemoteServer_OS_LOGON_WIN_NON_IBM_JRE;
-                return msg;
             }
 
             String s;

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -23,3 +23,6 @@ eclipse.temp.folder=/target_platform/prereqs/temp/plugins
 ant.prereqslib.folder=/ant_build/prereqs/lib
 ant.artifacts.folder=ant_build/artifacts/
 
+# Force use of TLS 1.2
+systemProp.com.ibm.jsse2.overrideDefaultTLS=true
+org.gradle.daemon=false


### PR DESCRIPTION
Fixes #264 

Remove the jdk check for Windows OS logon as it is no longer needed.