### PR TITLE
272 Respond to changes in the FeatureResource class

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/generation/ResolverFeatureAdapter.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/generation/ResolverFeatureAdapter.java
@@ -353,7 +353,7 @@ public class ResolverFeatureAdapter implements ProvisioningFeatureDefinition {
         }
 
         @Override
-        public String getRequiredOSGiEE() {
+        public Integer getRequireJava() {
             return null;
         }
 

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -23,3 +23,6 @@ eclipse.temp.folder=/target_platform/prereqs/temp/plugins
 ant.prereqslib.folder=/ant_build/prereqs/lib
 ant.artifacts.folder=ant_build/artifacts/
 
+# Force use of TLS 1.2
+systemProp.com.ibm.jsse2.overrideDefaultTLS=true
+org.gradle.daemon=false


### PR DESCRIPTION
Fixes #272

The com.ibm.ws.kernel.feature.provisioning.FeatureResource class was changed so ResolverFeatureAdapter.FeatureResource needs to be updated as well.

Removed: getRequiredOSGiEE()
Added: getRequireJava() (can return null for this since feature resolution is done statically in the tools so there are no Java requirements)