### PR TITLE
Issue #276: Update VariableValidationTest based on runtime changes

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/resources/validation/varDefect94757/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/varDefect94757/server.xml
@@ -23,5 +23,5 @@
                   
     <applicationMonitor pollingRate="1s500ms"/>         
     <connectionManager connectionTimeout="10s" maxIdleTime="10m30s" reapTime="5m10s500ms" agedTimeout="50mx"/>
-    <executor keepAlive="1d5h22m46s312ms"/>
+    <tcpOptions inactivityTimeout="1d5h22m46s312ms"/>
 </server>


### PR DESCRIPTION
Fixes #276 

Update the VariableValidationTest based on runtime changes - the keepAlive attribute was removed from the executor element.  Switch to another element and attribute with the same type.