### PR TITLE
Issue #282: Fix include conflict resolution for variables

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/validation/MergeRulesValidationTest.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/validation/MergeRulesValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,9 @@ public class MergeRulesValidationTest extends ValidationTestBase {
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "mergeRules5"));
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictMerge"));
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictIgnore"));
+        testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictIgnore2"));
+        testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictIgnore3"));
+        testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictIgnore4"));
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictReplace"));
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "includeConflictNested"));
         testSuite.addTest(TestSuite.createTest(MergeRulesValidationTest.class, "onConflictIgnoreReplace"));
@@ -278,6 +281,51 @@ public class MergeRulesValidationTest extends ValidationTestBase {
     }
 
     @Test
+    public void includeConflictIgnore2() throws Exception {
+        String serverName = "includeConflictIgnore2";
+        setupRuntimeServer(RESOURCE_PATH, serverName);
+        IFile file = getServerFile(serverName, "server.xml");
+        ValidatorMessage[] messages = TestUtil.validate(file);
+        checkMessageCount(messages, 0);
+
+        ConfigurationFile cf = getConfigFile(serverName);
+        assertNotNull("Configuration file is null.", cf);
+        int httpPort = cf.getHTTPPort();
+        assertTrue("Expecting the value of httpPort to be 8001 but the value was " + httpPort, httpPort == 8001);
+        deleteRuntimeServer(serverName);
+    }
+
+    @Test
+    public void includeConflictIgnore3() throws Exception {
+        String serverName = "includeConflictIgnore3";
+        setupRuntimeServer(RESOURCE_PATH, serverName);
+        IFile file = getServerFile(serverName, "server.xml");
+        ValidatorMessage[] messages = TestUtil.validate(file);
+        checkMessageCount(messages, 0);
+
+        ConfigurationFile cf = getConfigFile(serverName);
+        assertNotNull("Configuration file is null.", cf);
+        int httpPort = cf.getHTTPPort();
+        assertTrue("Expecting the value of httpPort to be 8001 but the value was " + httpPort, httpPort == 8001);
+        deleteRuntimeServer(serverName);
+    }
+
+    @Test
+    public void includeConflictIgnore4() throws Exception {
+        String serverName = "includeConflictIgnore4";
+        setupRuntimeServer(RESOURCE_PATH, serverName);
+        IFile file = getServerFile(serverName, "server.xml");
+        ValidatorMessage[] messages = TestUtil.validate(file);
+        checkMessageCount(messages, 0);
+
+        ConfigurationFile cf = getConfigFile(serverName);
+        assertNotNull("Configuration file is null.", cf);
+        int httpPort = cf.getHTTPPort();
+        assertTrue("Expecting the value of httpPort to be 8002 but the value was " + httpPort, httpPort == 8002);
+        deleteRuntimeServer(serverName);
+    }
+
+    @Test
     public void includeConflictReplace() throws Exception {
         String serverName = "includeConflictReplace";
         setupRuntimeServer(RESOURCE_PATH, serverName);
@@ -318,7 +366,7 @@ public class MergeRulesValidationTest extends ValidationTestBase {
         ConfigurationFile cf = getConfigFile(serverName);
         assertNotNull("Configuration file is null.", cf);
         int httpPort = cf.getHTTPPort();
-        assertTrue("Expecting the value of httpPort to be 9080 but the value was " + httpPort, httpPort == 9080);
+        assertTrue("Expecting the value of httpPort to be 9081 but the value was " + httpPort, httpPort == 9081);
         int httpsPort = cf.getHTTPSPort();
         assertTrue("Expecting the value of httpsPort to be 9444 but the value was " + httpsPort, httpsPort == 9444);
         deleteRuntimeServer(serverName);

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/a.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/a.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8001"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/b.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/b.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8002"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore2/server.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server description="Include with onConflict=IGNORE">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+    
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${port}"
+                  httpsPort="9443" />
+                  
+    <include location="a.xml"/>
+    <include location="b.xml" onConflict="IGNORE"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/a.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/a.xml
@@ -1,0 +1,14 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<include location="b.xml"/>
+	<include location="c.xml"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/b.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/b.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8001"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/c.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/c.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8002"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore3/server.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server description="Include with onConflict=IGNORE">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+    
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${port}"
+                  httpsPort="9443" />
+                  
+    <include location="a.xml" onConflict="IGNORE"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/a.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/a.xml
@@ -1,0 +1,14 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<include location="b.xml" onConflict="MERGE"/>
+	<include location="c.xml" onConflict="MERGE"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/b.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/b.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8001"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/c.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/c.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+	<variable name="port" value="8002"/>
+</server>

--- a/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/includeConflictIgnore4/server.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server description="Include with onConflict=IGNORE">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+    
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${port}"
+                  httpsPort="9443" />
+                  
+    <include location="a.xml" onConflict="IGNORE"/>
+</server>


### PR DESCRIPTION
Fixed the include conflict resolution for variables to work the same as the runtime.  The runtime has a master config and merges in each element as it sees it.  So even in the following case, the port will be 8001.

server.xml:
```
<server>
    <featureManager>
        <feature>servlet-4.0</feature>
        <feature>localConnector-1.0</feature>
    </featureManager>
 
    <httpEndpoint httpPort="${port}" httpsPort="9443" id="defaultHttpEndpoint"/>

    <applicationManager autoExpand="true"/>

    <include location="includeA.xml" onConflict="IGNORE"/>

    <applicationMonitor updateTrigger="mbean"/>
</server>
```

includeA.xml:
```
<server>
	<variable name="port" value="8001" />
	<variable name="port" value="8002" />
</server>
```