### PR TITLE
Issue #291: Remove applications from the server.xml for JAXWS sample tests

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/resources/sampleTesting/JAXWSEJBSample/server/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/sampleTesting/JAXWSEJBSample/server/server.xml
@@ -1,15 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
- -->
-<!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -27,7 +17,5 @@
     </featureManager>
 
 	<httpEndpoint id="defaultHttpEndpoint" httpPort="9130" />
-
-    <application id="JAXWSEJBSample" location="JAXWSEJBSample.ear" name="JAXWSEJBSample" type="ear" />
 
 </server>

--- a/dev/com.ibm.ws.st.core_tests/resources/sampleTesting/JAXWSWebSample/server/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/sampleTesting/JAXWSWebSample/server/server.xml
@@ -1,15 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
- -->
-<!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -26,7 +16,5 @@
     </featureManager>
     
     <httpEndpoint id="defaultHttpEndpoint" httpPort="9131" />
-
-    <application id="JAXWSWebSample" location="JAXWSWebSample.war" name="JAXWSWebSample" type="war"/>
 
 </server>


### PR DESCRIPTION
The JAXWS sample tests have the application already in the server.xml.  Remove it as the tools should be adding the application to the server as part of the test.

Also remove the duplicated copyright statements in server.xml.