### PR TITLE
Issue #316: Fix build issue with incompatible type comparison

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/config/ConfigurationFile.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/config/ConfigurationFile.java
@@ -780,7 +780,11 @@ public class ConfigurationFile implements IAdaptable, IConfigurationElement {
             return null;
 
         String[] result = new String[libRefIds.size()];
-        return libRefIds.toArray(result);
+        
+        for (int i = 0; i < libRefIds.size(); i++) {
+        	result[i] = libRefIds.get(i);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
WDT build got failed with the following error message: 

[javac] /home/libbld/Liberty/jazz-build-engines/wasrtc/wasrtc.ws.liblinrh10.solo/build/dev/com.ibm.ws.st.ui.abbot_tests/src/com/ibm/ws/st/ui/abbot_tests/testers/config/SharedLibTester.java:108: error: incompatible types: List cannot be converted to String[]
[22-May-2019 11:22:24:593 BST] 00000023 [javac] String[] ids = app.getSharedLibRefs();
[22-May-2019 11:22:24:593 BST] 00000023 [javac] ^
[22-May-2019 11:22:24:593 BST] 00000023 [javac] 1 error