### PR TITLE
Issue #325: The jst.connector facet should be set to 1.7

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/resources/jee/JEEPublishJCA/ExampleRA/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/jee/JEEPublishJCA/ExampleRA/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -15,5 +15,5 @@
   <fixed facet="jst.connector"/>
   <fixed facet="java"/>
   <installed facet="java" version="1.8"/>
-  <installed facet="jst.connector" version="1.8"/>
+  <installed facet="jst.connector" version="1.7"/>
 </faceted-project>


### PR DESCRIPTION
Fixes #325 

Updating the Java version to 1.8 accidentally updated the jst.connector facet in the JEEPublishJCA test case to 1.8.  Put it back to 1.7.