### PR TITLE
Fix for breaking liberty-maven-plugin changes

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.ibm.etools.maven.liberty.integration;singleton:=true
-Bundle-Version: 1.2.1.qualifier
+Bundle-Version: 1.2.2.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
@@ -186,8 +186,11 @@ public class LibertyMaven implements ILibertyBuildPluginImpl {
 
     /** {@inheritDoc} */
     @Override
-    public void updateSrcConfig(IPath location, LibertyBuildPluginConfiguration config, IProgressMonitor monitor) {
-        String goal = "package liberty:install-apps";
+    public void updateSrcConfig(IProject project, LibertyBuildPluginConfiguration config, IProgressMonitor monitor) {
+        IPath location = project.getLocation();
+        boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(project).useLegacyMvnGoal(monitor);
+        String goal = useLegacyRepublishCmd ? "package liberty:install-apps" : "package liberty:deploy";
+
         runMavenGoal(location, goal, config.getActiveBuildProfiles(), monitor);
     }
 
@@ -225,7 +228,8 @@ public class LibertyMaven implements ILibertyBuildPluginImpl {
         // Check if the server directory exists in the user directory before attempting to create it
         if (!serverPath.toFile().exists()) {
             // if the path doesn't exist then run the maven goal to create the server files
-            String goal = "package liberty:install-apps";
+            boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(project).useLegacyMvnGoal(monitor);
+            String goal = useLegacyRepublishCmd ? "package liberty:install-apps" : "package liberty:deploy";
             Trace.trace(Trace.INFO, "Running " + goal + " goal on project: " + project.getName());
             runMavenGoal(project.getLocation(), goal, profiles, monitor);
         }

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/manager/internal/MavenProjectInspector.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/manager/internal/MavenProjectInspector.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IFile;
@@ -214,6 +215,30 @@ public class MavenProjectInspector implements IProjectInspector {
             return null;
 
         return MavenPlugin.getMaven().readProject(location.toFile(), monitor);
+    }
+
+    @Override
+    public String getLibertyPluginVersion(IProgressMonitor monitor) throws CoreException {
+        for (Plugin plugin : getMavenProject(monitor).getBuildPlugins()) {
+            if ("liberty-maven-plugin".equals(plugin.getArtifactId())) {
+                return plugin.getVersion();
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public boolean useLegacyMvnGoal(IProgressMonitor monitor) {
+        try {
+            String libertyPluginVersion = getLibertyPluginVersion(monitor);
+            if (libertyPluginVersion.indexOf('.') > 0) {
+                String majorVersion = libertyPluginVersion.substring(0, libertyPluginVersion.indexOf('.'));
+                return Integer.parseInt(majorVersion) < 3;
+            }
+        } catch (Exception e) {
+            // default to false
+        }
+        return false;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
@@ -207,7 +207,9 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
 
                                     int publishUnitKind = publishUnit.getDeltaKind();
                                     if (ServerBehaviourDelegate.ADDED == publishUnitKind || ServerBehaviourDelegate.CHANGED == publishUnitKind) {
-                                        final String mvnRepublishCmd = "war:war liberty:install-apps";
+                                        boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(moduleProject).useLegacyMvnGoal(monitor);
+
+                                        final String mvnRepublishCmd = useLegacyRepublishCmd ? "war:war liberty:install-apps" : "war:war liberty:deploy";
 
                                         // In the unlikely event that any of these values are null, it should be handled
                                         // It is possible the user removes some entries from the liberty plugin config to reach this state
@@ -217,7 +219,7 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                                         } else {
                                             LibertyMaven.runMavenGoal(moduleProject.getLocation(), mvnRepublishCmd, config.getActiveBuildProfiles(), monitor);
 
-                                            // Calling the mvn goal "war:war liberty:install-apps" will reset the server.xml, so the
+                                            // Calling the mvn goal "war:war liberty:deploy" will reset the server.xml, so the
                                             // local connector and mbean have to be added back
                                             wsServer.ensureLocalConnectorAndAppMBeanConfig(monitor);
 
@@ -246,7 +248,7 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                             else if (getBuildPluginImpl().isDependencyModule(moduleProject, wsServer.getServer())) {
                                 /*
                                  * The module project isn't mapped directly but it could be a dependency project.
-                                 * In that case we should call install-apps on the parent for the non-loose config case and for loose config call the JEEPublisher.
+                                 * In that case we should call deploy on the parent for the non-loose config case and for loose config call the JEEPublisher.
                                  */
                                 if (wsServer.isLooseConfigEnabled()) {
                                     // In the loose config case, call the JEEPublisher implementation
@@ -265,8 +267,9 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                                         String installGoal = "install";
                                         LibertyMaven.runMavenGoal(moduleProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);
                                     }
-
-                                    String installGoal = "liberty:install-apps";
+                                    
+                                    boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(moduleProject).useLegacyMvnGoal(monitor);
+                                    final String installGoal = useLegacyRepublishCmd ? "liberty:install-apps" : "liberty:deploy";
                                     Trace.trace(Trace.INFO, "Running " + installGoal + " goal on project: " + mappedProject.getName());
                                     LibertyMaven.runMavenGoal(mappedProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);
                                     wsServer.ensureLocalConnectorAndAppMBeanConfig(monitor);

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.ibm.ws.st.liberty.buildplugin.integration;singleton:=true
-Bundle-Version: 1.0.2.qualifier
+Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/ILibertyBuildPluginImpl.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/ILibertyBuildPluginImpl.java
@@ -51,11 +51,11 @@ public interface ILibertyBuildPluginImpl {
     /**
      * Updates the source configuration using a build plugin goal or task execution.
      *
-     * @param projectLocation <code>IPath</code> of the project's location
+     * @param project The <code>IProject</code>
      * @param config The build plugin configuration
      * @param monitor
      */
-    void updateSrcConfig(IPath projectLocation, LibertyBuildPluginConfiguration config, IProgressMonitor monitor);
+    void updateSrcConfig(IProject project, LibertyBuildPluginConfiguration config, IProgressMonitor monitor);
 
     /**
      * Get the liberty build plugin configuration for the given project.
@@ -95,7 +95,7 @@ public interface ILibertyBuildPluginImpl {
      * Validates whether the project is a dependency module that should be deployed to the server.
      *
      * @param moduleProject the project to check
-     * @param server the server that it could be deployed to
+     * @param server        the server that it could be deployed to
      * @return
      */
     public boolean isDependencyModule(IProject moduleProject, IServer server);

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/IProjectInspector.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/IProjectInspector.java
@@ -86,4 +86,22 @@ public interface IProjectInspector {
      */
     public IModule[] getProjectModules();
 
+    /**
+     * Gets the liberty-maven-plugin version.
+     *
+     * @param monitor
+     * @return the version of the plugin
+     * @throws CoreException
+     */
+    public String getLibertyPluginVersion(IProgressMonitor monitor) throws CoreException;
+
+    /**
+     * Determine whether the legacy liberty maven plugin goal for installing the app should be used.
+     *
+     * @param project
+     * @param monitor
+     * @return
+     */
+    public boolean useLegacyMvnGoal(IProgressMonitor monitor);
+
 }

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/manager/internal/AbstractLibertyManager.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/manager/internal/AbstractLibertyManager.java
@@ -368,8 +368,7 @@ public abstract class AbstractLibertyManager implements IResourceChangeListener,
                 return false;
 
             // Delegate to the build plugin to copy the source file to the output directory
-            IPath location = project.getLocation();
-            buildPluginHelper.updateSrcConfig(location, config, monitor);
+            buildPluginHelper.updateSrcConfig(project, config, monitor);
 
             // Change the server to republish state so it will process the changed file on the next publish operation
             WebSphereServerBehaviour wsb = wsServer.getWebSphereServerBehaviour();

--- a/dev/com.ibm.ws.st.liberty.tools.base/feature.xml
+++ b/dev/com.ibm.ws.st.liberty.tools.base/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.ibm.ws.st.liberty.tools.base"
       label="%featureName"
-      version="1.0.8.qualifier"
+      version="1.0.9.qualifier"
       provider-name="%providerName"
       plugin="com.ibm.ws.st.core">
 


### PR DESCRIPTION
# What this PR does
Fixes https://github.com/OpenLiberty/open-liberty-tools/issues/348

Uses the `liberty:install-apps` goal when dealing with a liberty-maven-plugin < 3.0, otherwise uses the `liberty:deploy` goal.

# How to test

## Sample Repository
https://github.com/rajivnathan/guide-maven-intro/tree/liberty-maven-plugin

## Projects to demonstrate the fix

Project | liberty-maven-plugin version | mvn goal used by tools 
--- | --- | ---
archetypeGen/ServletSample | 2.0 | liberty:install-apps
finish | 3.2 | liberty:deploy

## Instructions to test
1. Import the project as an existing maven project
2. Use Run As -> Maven Install to trigger the full build
3. Once the build completes you may be prompted to have a server automatically created for you. Select Yes.
4. You should see a Liberty server created in the `Servers` view. Start it and verify the app is working correctly.
5. Make a change to the `HelloServlet.java` file.
6. Once you save the file it should trigger a republish of the app that makes use of the appropriate liberty maven goal according to the table above.
7. Verify the update worked
