### PR TITLE
Fix liberty gradle plugin build problem

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/internal/LibertyMaven.java
@@ -188,7 +188,9 @@ public class LibertyMaven implements ILibertyBuildPluginImpl {
     @Override
     public void updateSrcConfig(IProject project, LibertyBuildPluginConfiguration config, IProgressMonitor monitor) {
         IPath location = project.getLocation();
-        boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(project).useLegacyMvnGoal(monitor);
+        MavenProjectInspector mavenProjectInspector = (MavenProjectInspector) LibertyMaven.getInstance().getProjectInspector(project);
+        boolean useLegacyRepublishCmd = mavenProjectInspector.useLegacyMvnGoal(monitor);
+
         String goal = useLegacyRepublishCmd ? "package liberty:install-apps" : "package liberty:deploy";
 
         runMavenGoal(location, goal, config.getActiveBuildProfiles(), monitor);
@@ -228,7 +230,8 @@ public class LibertyMaven implements ILibertyBuildPluginImpl {
         // Check if the server directory exists in the user directory before attempting to create it
         if (!serverPath.toFile().exists()) {
             // if the path doesn't exist then run the maven goal to create the server files
-            boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(project).useLegacyMvnGoal(monitor);
+            MavenProjectInspector mavenProjectInspector = (MavenProjectInspector) LibertyMaven.getInstance().getProjectInspector(project);
+            boolean useLegacyRepublishCmd = mavenProjectInspector.useLegacyMvnGoal(monitor);
             String goal = useLegacyRepublishCmd ? "package liberty:install-apps" : "package liberty:deploy";
             Trace.trace(Trace.INFO, "Running " + goal + " goal on project: " + project.getName());
             runMavenGoal(project.getLocation(), goal, profiles, monitor);

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/manager/internal/MavenProjectInspector.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/manager/internal/MavenProjectInspector.java
@@ -217,7 +217,13 @@ public class MavenProjectInspector implements IProjectInspector {
         return MavenPlugin.getMaven().readProject(location.toFile(), monitor);
     }
 
-    @Override
+    /**
+     * Gets the liberty-maven-plugin version.
+     *
+     * @param monitor
+     * @return the version of the plugin
+     * @throws CoreException
+     */
     public String getLibertyPluginVersion(IProgressMonitor monitor) throws CoreException {
         for (Plugin plugin : getMavenProject(monitor).getBuildPlugins()) {
             if ("liberty-maven-plugin".equals(plugin.getArtifactId())) {
@@ -227,7 +233,13 @@ public class MavenProjectInspector implements IProjectInspector {
         return "";
     }
 
-    @Override
+    /**
+     * Determine whether the legacy liberty maven plugin goal for installing the app should be used.
+     *
+     * @param project
+     * @param monitor
+     * @return
+     */
     public boolean useLegacyMvnGoal(IProgressMonitor monitor) {
         try {
             String libertyPluginVersion = getLibertyPluginVersion(monitor);

--- a/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
+++ b/dev/com.ibm.etools.maven.liberty.integration/src/com/ibm/etools/maven/liberty/integration/servertype/internal/LibertyMavenJEEPublisher.java
@@ -28,6 +28,7 @@ import com.ibm.etools.maven.liberty.integration.internal.Activator;
 import com.ibm.etools.maven.liberty.integration.internal.LibertyMaven;
 import com.ibm.etools.maven.liberty.integration.internal.Trace;
 import com.ibm.etools.maven.liberty.integration.manager.internal.LibertyMavenProjectMapping;
+import com.ibm.etools.maven.liberty.integration.manager.internal.MavenProjectInspector;
 import com.ibm.ws.st.core.internal.Constants;
 import com.ibm.ws.st.core.internal.PublishUnit;
 import com.ibm.ws.st.core.internal.WebSphereServer;
@@ -207,7 +208,8 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
 
                                     int publishUnitKind = publishUnit.getDeltaKind();
                                     if (ServerBehaviourDelegate.ADDED == publishUnitKind || ServerBehaviourDelegate.CHANGED == publishUnitKind) {
-                                        boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(moduleProject).useLegacyMvnGoal(monitor);
+                                        MavenProjectInspector mavenProjectInspector = (MavenProjectInspector) LibertyMaven.getInstance().getProjectInspector(moduleProject);
+                                        boolean useLegacyRepublishCmd = mavenProjectInspector.useLegacyMvnGoal(monitor);
 
                                         final String mvnRepublishCmd = useLegacyRepublishCmd ? "war:war liberty:install-apps" : "war:war liberty:deploy";
 
@@ -267,8 +269,9 @@ public class LibertyMavenJEEPublisher extends AbstractLibertyBuildPluginJEEPubli
                                         String installGoal = "install";
                                         LibertyMaven.runMavenGoal(moduleProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);
                                     }
-                                    
-                                    boolean useLegacyRepublishCmd = LibertyMaven.getInstance().getProjectInspector(moduleProject).useLegacyMvnGoal(monitor);
+
+                                    MavenProjectInspector mavenProjectInspector = (MavenProjectInspector) LibertyMaven.getInstance().getProjectInspector(moduleProject);
+                                    boolean useLegacyRepublishCmd = mavenProjectInspector.useLegacyMvnGoal(monitor);
                                     final String installGoal = useLegacyRepublishCmd ? "liberty:install-apps" : "liberty:deploy";
                                     Trace.trace(Trace.INFO, "Running " + installGoal + " goal on project: " + mappedProject.getName());
                                     LibertyMaven.runMavenGoal(mappedProject.getLocation(), installGoal, config.getActiveBuildProfiles(), monitor);

--- a/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/IProjectInspector.java
+++ b/dev/com.ibm.ws.st.liberty.buildplugin.integration/src/com/ibm/ws/st/liberty/buildplugin/integration/internal/IProjectInspector.java
@@ -86,22 +86,4 @@ public interface IProjectInspector {
      */
     public IModule[] getProjectModules();
 
-    /**
-     * Gets the liberty-maven-plugin version.
-     *
-     * @param monitor
-     * @return the version of the plugin
-     * @throws CoreException
-     */
-    public String getLibertyPluginVersion(IProgressMonitor monitor) throws CoreException;
-
-    /**
-     * Determine whether the legacy liberty maven plugin goal for installing the app should be used.
-     *
-     * @param project
-     * @param monitor
-     * @return
-     */
-    public boolean useLegacyMvnGoal(IProgressMonitor monitor);
-
 }

--- a/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradle.java
+++ b/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradle.java
@@ -204,8 +204,9 @@ public class LibertyGradle implements ILibertyBuildPluginImpl {
 
     /** {@inheritDoc} */
     @Override
-    public void updateSrcConfig(IPath location, LibertyBuildPluginConfiguration config, IProgressMonitor monitor) {
+    public void updateSrcConfig(IProject project, LibertyBuildPluginConfiguration config, IProgressMonitor monitor) {
         String[] tasks = new String[] {LibertyGradleConstants.LIBERTY_CREATE_TASK};
+        IPath location = project.getLocation();
         runGradleTask(location, tasks, null, monitor);
     }
 


### PR DESCRIPTION
Build failure:
```
[ant:echo] Started compilation of com.ibm.ws.st.liberty.gradle
[ant:javac] Compile failed; see the compiler error output for details.
[ant:echo] /Users/rajiv/git/open-liberty-tools/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradle.java:49: error: LibertyGradle is not abstract and does not override abstract method updateSrcConfig(IProject,LibertyBuildPluginConfiguration,IProgressMonitor) in ILibertyBuildPluginImpl
[ant:echo] public class LibertyGradle implements ILibertyBuildPluginImpl {
[ant:echo]        ^
[ant:echo] /Users/rajiv/git/open-liberty-tools/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradle.java:206: error: method does not override or implement a method from a supertype
[ant:echo]     @Override
[ant:echo]     ^
[ant:echo] /Users/rajiv/git/open-liberty-tools/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/manager/internal/GradleProjectInspector.java:38: error: GradleProjectInspector is not abstract and does not override abstract method useLegacyMvnGoal(IProgressMonitor) in IProjectInspector
[ant:echo] public class GradleProjectInspector implements IProjectInspector {
[ant:echo]        ^
[ant:echo] 3 errors
```