### PR TITLE
Issue #388: Check for null runtime location

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntimeLocator.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntimeLocator.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.internal;
 
@@ -90,7 +90,7 @@ public class WebSphereRuntimeLocator extends RuntimeLocatorDelegate {
                 // ignore existing runtimes
                 IRuntime[] runtimes = ServerCore.getRuntimes();
                 for (IRuntime runtime : runtimes) {
-                    if (runtime.getLocation().equals(path)) {
+                    if (runtime.getLocation() != null && runtime.getLocation().equals(path)) {
                         return null;
                     }
                 }


### PR DESCRIPTION
Check for null runtime location in the WebSphereRuntimeLocator getRuntimeFromDir method.