### PR TITLE
Issue #392: Make sure the unavailable element test works with older runtimes

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/resources/validation/unavailableElement/server.xml
+++ b/dev/com.ibm.ws.st.core_tests/resources/validation/unavailableElement/server.xml
@@ -30,19 +30,4 @@
     
     <application id="Sample" location="${server.config.dir}/myAppDir/Sample2.war" name="Sample2" type="war"/>
 
-    <dataSource jndiName="jdbc/exampleDS" id="ds1">
-        <jdbcDriver>
-            <library>
-                <fileset dir="C:\db-derby-10.8.2.2-bin\lib" includes="derby.jar"></fileset>
-            </library>
-        </jdbcDriver>
-        <properties.derby.embedded createDatabase="create" databaseName="${shared.resource.dir}/data/exampleDB"/>
-    </dataSource>
-    
-    
-    <jdbcDriver id="jdbcDriver">
-        <library>
-            <fileset dir="D:\derby\lib" includes="derby.jar"></fileset>
-        </library>
-    </jdbcDriver>
 </server>


### PR DESCRIPTION
Remove the elements that give errors with older runtimes so that the test will pass with old and new runtimes.