### PR TITLE
407 - Support Eclipse 2020.09

### DIFF
--- a/dev/com.ibm.ws.st.core/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.st.core/META-INF/MANIFEST.MF
@@ -29,6 +29,8 @@ Export-Package: com.ibm.websphere.crypto,
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Bundle-Activator: com.ibm.ws.st.core.internal.Activator
+Require-Bundle: org.eclipse.jdt.debug,
+ org.eclipse.core.runtime
 Import-Package: com.ibm.ws.kernel.feature,
  com.ibm.ws.kernel.feature.provisioning,
  com.ibm.ws.kernel.feature.resolver,
@@ -38,8 +40,6 @@ Import-Package: com.ibm.ws.kernel.feature,
  com.ibm.ws.st.common.core.ext.internal.setuphandlers,
  com.ibm.ws.st.common.core.ext.internal.util,
  com.ibm.ws.st.common.core.internal,
- com.sun.jdi;bundle-symbolic-name="org.eclipse.jdt.debug",
- com.sun.jdi.connect;bundle-symbolic-name="org.eclipse.jdt.debug",
  javax.json;bundle-symbolic-name="com.ibm.ws.st.common.core",
  javax.json.spi;bundle-symbolic-name="com.ibm.ws.st.common.core",
  javax.json.stream;bundle-symbolic-name="com.ibm.ws.st.common.core",


### PR DESCRIPTION
In Eclipse 2020.09 the org.eclipse.jdt.debug bundle stopped exporting
the com.sun.jdi package which stops the tools resolving. This
fix stops importing the package and switching to a Require-Bundle so
the package can be imported both on Eclipse 2020.09, but also earlier
releases.

Fixes issue #407 