### PR TITLE
Update target platform in gradle.properties to reference Eclipse download site

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -11,7 +11,7 @@
 
 # Target platform : Oxygen 
 eclipse.sdk.url=http://libh-wdt-file-repo.fyre.ibm.com/eclipseSDK/eclipse-SDK-4.7.3a-linux-gtk-x86_64.tar.gz
-eclipse.target.platform.url=http://mirror.csclub.uwaterloo.ca/eclipse/technology/epp/downloads/release/oxygen/3a/eclipse-jee-oxygen-3a-linux-gtk-x86_64.tar.gz
+eclipse.target.platform.url=http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/oxygen/3a/eclipse-jee-oxygen-3a-linux-gtk-x86_64.tar.gz
 
 eclipse.sdk.archive.location=/ant_build/eclipse_sdk.tar.gz
 eclipse.sdk.folder=/ant_build/eclipse_sdk/


### PR DESCRIPTION
The Waterloo University mirror no longer contains Oxygen 3A, and there is no longer a reason to use a mirror in Canada. This should fix the OLT build issues. Investigating consuming this from our own site going forward.