### PR TITLE
Update gradle task for liberty plugin

### DIFF
--- a/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradleConstants.java
+++ b/dev/com.ibm.ws.st.liberty.gradle/src/com/ibm/ws/st/liberty/gradle/internal/LibertyGradleConstants.java
@@ -34,7 +34,7 @@ public class LibertyGradleConstants {
     // tasks
     public static final String LIBERTY_CREATE_TASK = "libertyCreate";
     public static final String ASSEMBLE_TASK = "assemble";
-    public static final String INSTALL_APPS_TASK = "installApps";
+    public static final String INSTALL_APPS_TASK = "deploy";
     public static final String[] ASSEMBLE_INSTALL_APPS_TASKS = new String[] {ASSEMBLE_TASK, INSTALL_APPS_TASK};
     
     // arguments


### PR DESCRIPTION
Liberty gradle plugin has dropped the installApps task in favor of the deploy task so swap over to using that