### PR TITLE
Fix NPE in addConflictingFeatures

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntimeClasspathHelper.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WebSphereRuntimeClasspathHelper.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -225,7 +226,9 @@ class WebSphereRuntimeClasspathHelper {
      */
     private void addConflictingFeatures(Map<String, List<FeatureName>> featuresByPrefix, String... conflictingPrefixes) {
         List<FeatureName> conflictingNames = Arrays.stream(conflictingPrefixes)
-                                                   .flatMap(x -> featuresByPrefix.get(x).stream())
+                                                   .map(featuresByPrefix::get)
+                                                   .filter(Objects::nonNull)
+                                                   .flatMap(l -> l.stream())
                                                    .collect(Collectors.toList());
 
         for (FeatureName name : conflictingNames) {


### PR DESCRIPTION
We process a list of known clashing feature prefixes, but this code will
hit an NPE if one of the hard-coded prefixes doesn't match any feature
installed in the runtime.