### PR TITLE
Autopublish fix

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WASPublishControllerDelegate.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/WASPublishControllerDelegate.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.st.core.internal;
 
@@ -27,7 +27,19 @@ public class WASPublishControllerDelegate extends PublishControllerDelegate {
         WebSphereServer wsServer = (WebSphereServer) server.loadAdapter(WebSphereServer.class, null);
         if (wsServer == null)
             return true;
-
+        // 0 = unknown whether this value is used but if it is then treat it as disabled 
+        // 1 = autopublishing disabled
+        // 2 = autopublishing enabled
+        int autoPublishSettings = server.getAttribute("auto-publish-setting", 1);
+        if (Trace.ENABLED) {
+            Trace.trace(Trace.INFO, "WASPublishControllerDelegate.isPublishRequired autoPublishSettings=" + autoPublishSettings);
+        }
+        if (autoPublishSettings < 2) {
+            if (Trace.ENABLED) {
+                Trace.trace(Trace.INFO, "WASPublishControllerDelegate returning false as autopublish is disabled" + autoPublishSettings);
+            }
+            return false;
+        }
         WebSphereServerBehaviour behaviour = (WebSphereServerBehaviour) server.loadAdapter(WebSphereServerBehaviour.class, null);
         if (behaviour == null) // We should be able to load it
             return true;


### PR DESCRIPTION
Bypass publish checking if eclipse autopublish is disabled. Currently, even if Eclipse has auto publish set to disabled it still asks Open Liberty Tools to check if publishing is required. To work around this we will now check if auto publish is disabled and bypass the check, as this process is fairly intensive in larger projects. 