### PR TITLE
Remove version dependency to org.eclipse.m2e.maven.runtime

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
@@ -85,7 +85,7 @@ Import-Package: com.ibm.ws.st.liberty.buildplugin.integration.internal,
  org.eclipse.wst.validation,
  org.eclipse.wst.xml.core.internal.provisional.document,
  org.osgi.framework;version="[1.5.0,2.0.0)"
-Require-Bundle: org.eclipse.m2e.maven.runtime
+Require-Bundle: org.eclipse.m2e.maven.runtime,
  com.ibm.ws.st.ui,
  com.ibm.ws.st.core
 Export-Package: com.ibm.etools.maven.liberty.integration.internal,

--- a/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
@@ -85,7 +85,7 @@ Import-Package: com.ibm.ws.st.liberty.buildplugin.integration.internal,
  org.eclipse.wst.validation,
  org.eclipse.wst.xml.core.internal.provisional.document,
  org.osgi.framework;version="[1.5.0,2.0.0)"
-Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[1.1.0,2.0.0)",
+Require-Bundle: org.eclipse.m2e.maven.runtime
  com.ibm.ws.st.ui,
  com.ibm.ws.st.core
 Export-Package: com.ibm.etools.maven.liberty.integration.internal,


### PR DESCRIPTION
This change allows the plugin to install on Eclipse JEE v2022-06, v2022-09, v2022-12 ... but it does not guarantee that the rest of the code is still adapted to work with"org.eclipse.m2e.maven.runtime" v2.0+, eg v3.8 as included in Eclipse JEE v2022-06+

Probably more changes should be done to the code to benefit from the upgrade of the"org.eclipse.m2e.maven.runtime"plugin

Relates to issue OpenLiberty#460