### PR TITLE
Remove version dependency to org.eclipse.m2e.maven.runtime

### DIFF
--- a/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.etools.maven.liberty.integration/META-INF/MANIFEST.MF
@@ -85,7 +85,7 @@ Import-Package: com.ibm.ws.st.liberty.buildplugin.integration.internal,
  org.eclipse.wst.validation,
  org.eclipse.wst.xml.core.internal.provisional.document,
  org.osgi.framework;version="[1.5.0,2.0.0)"
-Require-Bundle: org.eclipse.m2e.maven.runtime;bundle-version="[1.1.0,2.0.0)",
+Require-Bundle: org.eclipse.m2e.maven.runtime
  com.ibm.ws.st.ui,
  com.ibm.ws.st.core
 Export-Package: com.ibm.etools.maven.liberty.integration.internal,


### PR DESCRIPTION
Thank you for the update, on the surface I think your fix would work but would like to run our automation tests against it. So I'm pushing this into a test branch that I can build against to try it out

Remove version dependency to org.eclipse.m2e.maven.runtime to allow the plugin to install on Eclipse JEE v2022-06,v2022-09,v2022-12

