### PR TITLE
Issue #488:Update liberty shutdown timer to 30 seconds

### DIFF
--- a/dev/com.ibm.ws.st.was.core/plugin.xml
+++ b/dev/com.ibm.ws.st.was.core/plugin.xml
@@ -66,7 +66,7 @@
       hasConfiguration="false"
       launchModes="run,debug"
       startTimeout="60000"
-      stopTimeout="15000"
+      stopTimeout="30000"
       initialState="stopped"
       supportsRemoteHosts="true"
       launchConfigId="com.ibm.ws.st.core.launchConfigurationType"


### PR DESCRIPTION
Update the default liberty server shutdown timer to 30 seconds (from 15)