### PR TITLE
Issue #481: port conflicts

### DIFF
--- a/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/config/ConfigurationFile.java
+++ b/dev/com.ibm.ws.st.core/src/com/ibm/ws/st/core/internal/config/ConfigurationFile.java
@@ -834,7 +834,8 @@ public class ConfigurationFile implements IAdaptable, IConfigurationElement {
             contextRoot = null;
         }
 
-        Application app = new Application(appName, ServerExtensionWrapper.getAppTypeFromAppElement(appLabel), appLocation, appAutostart, getSharedLibRefs(appElem), apiVisibility, contextRoot);
+        Application app = new Application(appName, ServerExtensionWrapper.getAppTypeFromAppElement(appLabel), appLocation, appAutostart, getSharedLibRefs(appElem), apiVisibility,
+                        contextRoot);
         return app;
     }
 
@@ -1639,6 +1640,11 @@ public class ConfigurationFile implements IAdaptable, IConfigurationElement {
             return value;
         }
         ConfigVars vars = getConfigVars();
+        String envValue = value.replace("${", "${env.");
+        String resolvedEnvValue = vars.resolve(envValue);
+        if (resolvedEnvValue != null) {
+            return resolvedEnvValue;
+        }
         return vars.resolve(value.trim());
     }
 


### PR DESCRIPTION
PR to allow server.env values to be used for port numbers

Example information returned from values that this code deals with 

```
values: {
 wlp.server.name=wdt-server, 
 server.config.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\servers\wdt-server, 
 >> HTTP_PORT=9080, 
 >> env.HTTP_PORT=9081, 
 wlp.install.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime, 
 >> HTTPS_PORT=9443,
 >> env.HTTPS_PORT=9444, 
 shared.config.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\shared\config, 
 usr.extension.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\extension, 
 shared.resource.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\shared\resources, 
 wlp.user.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr, 
 server.output.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\servers\wdt-server, 
 >> env.keystore_password=REDACTED, 
 shared.app.dir=C:\__DoNotBkup\_wdt\26-server.env\2023-12R-WDT\wsWDTruntime\usr\shared\apps
}
```