### PR TITLE
Defer activator code that requires UI thread

### DIFF
--- a/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/Activator.java
+++ b/dev/com.ibm.ws.st.ui/src/com/ibm/ws/st/ui/internal/Activator.java
@@ -166,6 +166,8 @@ public class Activator extends AbstractUIPlugin {
     public static final String IMG_SSL_ELEM = "sslElem";
     public static final String IMG_HTTP_ELEM = "httpElem";
 
+    private boolean initComplete = false;
+
     public Activator() {
         // do nothing
     }
@@ -186,8 +188,6 @@ public class Activator extends AbstractUIPlugin {
 
         addRequiredFeatureListener();
         MergedConfigResourceListener.start();
-
-        PlatformUI.getWorkbench().getProgressService().registerIconForFamily(getImageDescriptor(IMG_RUNTIME), com.ibm.ws.st.core.internal.Constants.JOB_FAMILY);
     }
 
     private static void addRequiredFeatureListener() {
@@ -368,6 +368,12 @@ public class Activator extends AbstractUIPlugin {
      * @return the shared instance
      */
     public static Activator getInstance() {
+        synchronized (instance) {
+            if (!instance.initComplete) {
+                instance.initComplete = true;
+                PlatformUI.getWorkbench().getProgressService().registerIconForFamily(getImageDescriptor(IMG_RUNTIME), com.ibm.ws.st.core.internal.Constants.JOB_FAMILY);
+            }
+        }
         return instance;
     }
 
@@ -398,6 +404,7 @@ public class Activator extends AbstractUIPlugin {
             }
         });
         ImageRegistry registry = tempRegistryArray[0];
+
         if (ICON_BASE_URL == null)
             ICON_BASE_URL = instance.getBundle().getEntry("icons/");
 


### PR DESCRIPTION
Due to a change in Eclipse that required some code to run on the UI thread we had updated our code to run a syncExec to achieve this.

The deadlock problem appears to be caused by the following:

The bundle is starting up and during startup it tries to register an icon which requires an image registry which in turn needed to be run on a UI thread so this thread is sitting waiting for a slot on the UI thread.

The UI thread is waiting for all the bundles to start up and is hitting timeouts loading classes which eventually does continue and unblocks but does cause a hang while this happens.

The fix is defer the registering of an icon so that instead of happening during the activator starting up it happens whenever a thread tries to access the singleton bundle instance for the first time (which is typically when Eclipse asks us for an icon). This means that the bundle can complete it's startup without requiring access to the UI thread. This in turn means the UI thread that is waiting for the bundles to startup can continue and not hit timeouts on classloading.