### PR TITLE
Update gradle to 8.5 for java 21 support

### DIFF
--- a/dev/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
By pulling in a newer Open Liberty which was compiled with Java 19 we need to upgrade gradle (go straight to Java 21 LTS version)