### PR TITLE
Update server stop wait period to 300 seconds / 5 minutes

### DIFF
--- a/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/util/ServerTestUtil.java
+++ b/dev/com.ibm.ws.st.core_tests/bvt/src/com/ibm/ws/st/core/tests/util/ServerTestUtil.java
@@ -167,8 +167,8 @@ public class ServerTestUtil {
         print("Server stop operation status: " + opStatus[0]);
 
         print("Server stop operation completed.");
-        // give it 30 second for the server state to be updated (for CCB build)
-        int i = 60;
+        // give it 300 seconds (5 minutes) for the server state to be updated (for CCB build)
+        int i = 600;
         while (server.getServerState() != IServer.STATE_STOPPED && --i > 0) {
             print("Server state: " + server.getServerState());
             Thread.sleep(500);


### PR DESCRIPTION
Update server stop wait period to give more time for server to shutdown and not cause test failures