### PR TITLE
fix issue with appclient and ear version definition

### DIFF
--- a/dev/com.ibm.ws.st.jee.core/plugin.xml
+++ b/dev/com.ibm.ws.st.jee.core/plugin.xml
@@ -58,7 +58,7 @@
         version="1.0"/>
       <facet
         id="jst.ear"
-        version="1.2,1.3,1.4,5.0,6.0,7.0,8.0,9.0,10.0"/>
+        version="1.2,1.3,1.4,5.0,6.0"/>
       <facet
         id="jst.utility"
         version="1.0"/>
@@ -114,30 +114,18 @@
     </supported>
   </extension>
   <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
-    <runtime-component-type id="com.ibm.ws.st.runtime.appclient"/>
-    <runtime-component-version type="com.ibm.ws.st.runtime.appclient" version="7.0"/>
+    <runtime-component-type id="com.ibm.ws.st.runtime.appclientsupport"/>
+    <runtime-component-version type="com.ibm.ws.st.runtime.appclientsupport" version="1.0"/>
     <supported>
-      <facet id="jst.appclient" version="1.2,1.3,1.4,5.0,6.0,7.0"/>
-    </supported>
-  </extension>
-  <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
-    <runtime-component-type id="com.ibm.ws.st.runtime.appclient"/>
-    <runtime-component-version type="com.ibm.ws.st.runtime.appclient" version="8.0"/>
-    <supported>
+      <runtime-component id="com.ibm.ws.st.runtime.appclientsupport" version="1.0"/>
       <facet id="jst.appclient" version="1.2,1.3,1.4,5.0,6.0,7.0,8.0"/>
     </supported>
   </extension>
-    <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
-    <runtime-component-type id="com.ibm.ws.st.runtime.appclient"/>
-    <runtime-component-version type="com.ibm.ws.st.runtime.appclient" version="9.0"/>
-    <supported>
-      <facet id="jst.appclient" version="1.2,1.3,1.4,5.0,6.0,7.0,8.0,9.0"/>
-    </supported>
-  </extension>
   <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
-    <runtime-component-type id="com.ibm.ws.st.runtime.appclient"/>
-    <runtime-component-version type="com.ibm.ws.st.runtime.appclient" version="10.0"/>
+    <runtime-component-type id="com.ibm.ws.st.runtime.appclientsupport"/>
+    <runtime-component-version type="com.ibm.ws.st.runtime.appclientsupport" version="2.0"/>
     <supported>
+      <runtime-component id="com.ibm.ws.st.runtime.appclientsupport" version="2.0"/>
       <facet id="jst.appclient" version="1.2,1.3,1.4,5.0,6.0,7.0,8.0,9.0,10.0"/>
     </supported>
   </extension>


### PR DESCRIPTION
- Fixed application client and EAR facet version definitions in plugin.xml to properly control what appears in the Eclipse wizard.
  - Basic runtime component supports EAR versions 1.2-6.0 and EAR versions 7.0-10.0 are supported through separate enterpriseApplication runtime components
- The previous application client configuration was incorrect because it was missing the `<runtime-component>` element in the `<supported>` section. This caused all defined application client versions to be incorrectly listed in the Eclipse application client creator wizard, regardless of the actual runtime support.
  - Updated to align with Open Liberty's [Application Client Support feature specification](https://openliberty.io/docs/latest/reference/feature/appClientSupport-2.0.html)

-   A fix is also needed in WTP code to correctly handle Jakarta EE 10+ versions : https://github.com/eclipse-wtp-common/webtools.common/pull/23